### PR TITLE
[RTM] add error for model path type

### DIFF
--- a/bioptim/interfaces/biorbd_model.py
+++ b/bioptim/interfaces/biorbd_model.py
@@ -9,8 +9,10 @@ class BiorbdModel:
     def __init__(self, bio_model: str | biorbd.Model):
         if isinstance(bio_model, str):
             self.model = biorbd.Model(bio_model)
-        else:
+        elif isinstance(bio_model, biorbd.Model):
             self.model = bio_model
+        else:
+            raise RuntimeError("Type must be a string or a biorbdmodel")
 
     def deep_copy(self, *args):
         return BiorbdModel(self.model.DeepCopy(*args))

--- a/bioptim/interfaces/biorbd_model.py
+++ b/bioptim/interfaces/biorbd_model.py
@@ -12,7 +12,7 @@ class BiorbdModel:
         elif isinstance(bio_model, biorbd.Model):
             self.model = bio_model
         else:
-            raise RuntimeError("Type must be a string or a biorbdmodel")
+            raise RuntimeError("Type must be a 'str' or a 'biorbd.Model'")
 
     def deep_copy(self, *args):
         return BiorbdModel(self.model.DeepCopy(*args))

--- a/tests/test_biorbd_model.py
+++ b/tests/test_biorbd_model.py
@@ -21,5 +21,8 @@ def test_biorbd_model_import():
 
     BiorbdModel(biorbd.Model(bioptim_folder + model_path))
 
-    with pytest.raises(RuntimeError, match="Type must be a string or a biorbdmodel"):
+    with pytest.raises(RuntimeError, match="Type must be a 'str' or a 'biorbd.Model'"):
         BiorbdModel(1)
+
+    with pytest.raises(RuntimeError, match="Type must be a 'str' or a 'biorbd.Model'"):
+        BiorbdModel([])

--- a/tests/test_biorbd_model.py
+++ b/tests/test_biorbd_model.py
@@ -5,40 +5,20 @@ It tests that a model path with another type than string or biorbdmodel return a
 
 import os
 import pytest
-
-import numpy as np
+import biorbd_casadi as biorbd
 from bioptim import (
-    OdeSolver,
+    BiorbdModel,
 )
 
-from .utils import TestUtils
-
-
-@pytest.mark.parametrize("model", ["/models/pendulum.bioMod"])
-def test_biorbd_model_fail(model):
+def test_biorbd_model_fail():
     # Load pendulum_min_time_Mayer
     from bioptim.examples.getting_started import pendulum as ocp_module
 
     bioptim_folder = os.path.dirname(ocp_module.__file__)
+    model_path = "/models/pendulum.bioMod"
+    BiorbdModel(bioptim_folder + model_path)
+
+    BiorbdModel(biorbd.Model(bioptim_folder + model_path))
 
     with pytest.raises(RuntimeError, match="Type must be a string or a biorbdmodel"):
-        ocp = ocp_module.prepare_ocp(
-            biorbd_model_path=[bioptim_folder + model],
-            final_time=2,
-            n_shooting=10,
-            ode_solver=OdeSolver.COLLOCATION(),
-        )
-    with pytest.raises(RuntimeError, match="Type must be a string or a biorbdmodel"):
-        ocp = ocp_module.prepare_ocp(
-            biorbd_model_path=np.array(bioptim_folder + model),
-            final_time=2,
-            n_shooting=10,
-            ode_solver=OdeSolver.COLLOCATION(),
-        )
-    with pytest.raises(RuntimeError, match="Type must be a string or a biorbdmodel"):
-        ocp = ocp_module.prepare_ocp(
-            biorbd_model_path=1,
-            final_time=2,
-            n_shooting=10,
-            ode_solver=OdeSolver.COLLOCATION(),
-        )
+        BiorbdModel(1)

--- a/tests/test_biorbd_model.py
+++ b/tests/test_biorbd_model.py
@@ -10,8 +10,9 @@ from bioptim import (
     BiorbdModel,
 )
 
-def test_biorbd_model_fail():
-    # Load pendulum_min_time_Mayer
+
+def test_biorbd_model_import():
+
     from bioptim.examples.getting_started import pendulum as ocp_module
 
     bioptim_folder = os.path.dirname(ocp_module.__file__)

--- a/tests/test_biorbd_model.py
+++ b/tests/test_biorbd_model.py
@@ -1,0 +1,44 @@
+"""
+Test for file IO.
+It tests that a model path with another type than string or biorbdmodel return an error
+"""
+
+import os
+import pytest
+
+import numpy as np
+from bioptim import (
+    OdeSolver,
+)
+
+from .utils import TestUtils
+
+
+@pytest.mark.parametrize("model", ["/models/pendulum.bioMod"])
+def test_biorbd_model_fail(model):
+    # Load pendulum_min_time_Mayer
+    from bioptim.examples.getting_started import pendulum as ocp_module
+
+    bioptim_folder = os.path.dirname(ocp_module.__file__)
+
+    with pytest.raises(RuntimeError, match="Type must be a string or a biorbdmodel"):
+        ocp = ocp_module.prepare_ocp(
+            biorbd_model_path=[bioptim_folder + model],
+            final_time=2,
+            n_shooting=10,
+            ode_solver=OdeSolver.COLLOCATION(),
+        )
+    with pytest.raises(RuntimeError, match="Type must be a string or a biorbdmodel"):
+        ocp = ocp_module.prepare_ocp(
+            biorbd_model_path=np.array(bioptim_folder + model),
+            final_time=2,
+            n_shooting=10,
+            ode_solver=OdeSolver.COLLOCATION(),
+        )
+    with pytest.raises(RuntimeError, match="Type must be a string or a biorbdmodel"):
+        ocp = ocp_module.prepare_ocp(
+            biorbd_model_path=1,
+            final_time=2,
+            n_shooting=10,
+            ode_solver=OdeSolver.COLLOCATION(),
+        )


### PR DESCRIPTION
add an error if the type of the model path is not correct + new example to test model path type

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/bioptim/605)
<!-- Reviewable:end -->
