### PR TITLE
[RTR] Fix for the multi node constraint bug ?

### DIFF
--- a/bioptim/limits/penalty_option.py
+++ b/bioptim/limits/penalty_option.py
@@ -427,6 +427,7 @@ class PenaltyOption(OptionGeneric):
             self.all_nodes_index = []
             for ctrl in controllers:
                 self.all_nodes_index.extend(ctrl.t)
+                ctrl.node_index = ctrl.t
 
             state_cx_scaled = ocp.cx()
             control_cx_scaled = ocp.cx()


### PR DESCRIPTION
I think the node index was not set, therefore multi node constraints on the same phase gave a free variable error

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/bioptim/691)
<!-- Reviewable:end -->
