### PR TITLE
[RTR] duplicate_collocation_starting_point

### DIFF
--- a/bioptim/dynamics/integrator.py
+++ b/bioptim/dynamics/integrator.py
@@ -662,7 +662,7 @@ class COLLOCATION(Integrator):
 
         self.method = ode_opt["method"]
         self.degree = ode_opt["irk_polynomial_interpolation_degree"]
-        self.include_starting_collocation_point = ode_opt["include_starting_collocation_point"]
+        self.duplicate_collocation_starting_point = ode_opt["duplicate_collocation_starting_point"]
         self.allow_free_variables = ode_opt["allow_free_variables"]
 
         # Coefficients of the collocation equation
@@ -819,7 +819,7 @@ class COLLOCATION(Integrator):
         self.function = Function(
             "integrator",
             [
-                horzcat(*self.x_sym) if self.include_starting_collocation_point else horzcat(*self.x_sym[1:]),
+                horzcat(*self.x_sym) if self.duplicate_collocation_starting_point else horzcat(*self.x_sym[1:]),
                 self.u_sym,
                 self.param_sym,
                 self.s_sym,
@@ -911,7 +911,7 @@ class IRK(COLLOCATION):
 
         # Root-finding function, implicitly defines x_collocation_points as a function of x0 and p
         time_sym = []
-        collocation_states = vertcat(*states[1:]) if self.include_starting_collocation_point else vertcat(*states[2:])
+        collocation_states = vertcat(*states[1:]) if self.duplicate_collocation_starting_point else vertcat(*states[2:])
         vfcn = Function(
             "vfcn",
             [collocation_states, time_sym, states[0], controls, params, stochastic_variables],

--- a/bioptim/dynamics/ode_solver.py
+++ b/bioptim/dynamics/ode_solver.py
@@ -330,7 +330,7 @@ class OdeSolver:
             The method of interpolation ("legendre" or "radau")
         defects_type: DefectType
             The type of defect to use (DefectType.EXPLICIT or DefectType.IMPLICIT)
-        include_starting_collocation_point: bool
+        duplicate_collocation_starting_point: bool
             Whether an additional collocation point should be added at the shooting node (this is typically used in SOCPs)
 
         Methods
@@ -344,7 +344,7 @@ class OdeSolver:
             polynomial_degree: int = 4,
             method: str = "legendre",
             defects_type: DefectType = DefectType.EXPLICIT,
-            include_starting_collocation_point: bool = False,
+            duplicate_collocation_starting_point: bool = False,
         ):
             """
             Parameters
@@ -355,8 +355,8 @@ class OdeSolver:
 
             super(OdeSolver.COLLOCATION, self).__init__()
             self.polynomial_degree = polynomial_degree
-            self.include_starting_collocation_point = include_starting_collocation_point
-            self.n_cx = polynomial_degree + 3 if include_starting_collocation_point else polynomial_degree + 2
+            self.duplicate_collocation_starting_point = duplicate_collocation_starting_point
+            self.n_cx = polynomial_degree + 3 if duplicate_collocation_starting_point else polynomial_degree + 2
             self.rk_integrator = COLLOCATION
             self.method = method
             self.defects_type = defects_type
@@ -384,7 +384,7 @@ class OdeSolver:
                     "developers and ping @EveCharbie"
                 )
 
-            if self.include_starting_collocation_point:
+            if self.duplicate_collocation_starting_point:
                 x_unscaled = ([nlp.states.cx_start] + nlp.states.cx_intermediates_list,)
                 x_scaled = [nlp.states.scaled.cx_start] + nlp.states.scaled.cx_intermediates_list
             else:
@@ -423,7 +423,7 @@ class OdeSolver:
                 "irk_polynomial_interpolation_degree": self.polynomial_degree,
                 "method": self.method,
                 "defects_type": self.defects_type,
-                "include_starting_collocation_point": self.include_starting_collocation_point,
+                "duplicate_collocation_starting_point": self.duplicate_collocation_starting_point,
                 "allow_free_variables": allow_free_variables,
             }
 

--- a/bioptim/examples/stochastic_optimal_control/obstacle_avoidance_direct_collocation.py
+++ b/bioptim/examples/stochastic_optimal_control/obstacle_avoidance_direct_collocation.py
@@ -300,7 +300,7 @@ def prepare_socp(
         ode_solver = OdeSolver.COLLOCATION(
             polynomial_degree=socp_type.polynomial_degree,
             method=socp_type.method,
-            include_starting_collocation_point=True,
+            duplicate_collocation_starting_point=True,
         )
 
         return OptimalControlProgram(

--- a/bioptim/limits/penalty.py
+++ b/bioptim/limits/penalty.py
@@ -1170,7 +1170,7 @@ class PenaltyFunctionAbstract:
         def first_collocation_point_equals_state(penalty: PenaltyOption, controller: PenaltyController | list):
             """
             Insures that the first collocation helper is equal to the states at the shooting node.
-            This is a necessary constraint for COLLOCATION with include_starting_collocation_point.
+            This is a necessary constraint for COLLOCATION with duplicate_collocation_starting_point.
             """
             collocation_helper = controller.states.cx_intermediates_list[0]
             states = controller.states.cx_start

--- a/bioptim/optimization/optimal_control_program.py
+++ b/bioptim/optimization/optimal_control_program.py
@@ -955,7 +955,7 @@ class OptimalControlProgram:
                         ConstraintFcn.STATE_CONTINUITY, node=Node.ALL_SHOOTING, penalty_type=PenaltyType.INTERNAL
                     )
                     penalty.add_or_replace_to_penalty_pool(self, nlp)
-                    if nlp.ode_solver.is_direct_collocation and nlp.ode_solver.include_starting_collocation_point:
+                    if nlp.ode_solver.is_direct_collocation and nlp.ode_solver.duplicate_collocation_starting_point:
                         penalty = Constraint(
                             ConstraintFcn.FIRST_COLLOCATION_HELPER_EQUALS_STATE,
                             node=Node.ALL_SHOOTING,
@@ -968,7 +968,7 @@ class OptimalControlProgram:
                             ConstraintFcn.STATE_CONTINUITY, node=shooting_node, penalty_type=PenaltyType.INTERNAL
                         )
                         penalty.add_or_replace_to_penalty_pool(self, nlp)
-                        if nlp.ode_solver.is_direct_collocation and nlp.ode_solver.include_starting_collocation_point:
+                        if nlp.ode_solver.is_direct_collocation and nlp.ode_solver.duplicate_collocation_starting_point:
                             penalty = Constraint(
                                 ConstraintFcn.FIRST_COLLOCATION_HELPER_EQUALS_STATE,
                                 node=shooting_node,

--- a/bioptim/optimization/solution/simplified_objects.py
+++ b/bioptim/optimization/solution/simplified_objects.py
@@ -90,11 +90,11 @@ class SimplifiedNLP:
         Generate time vector steps for a phase considering all the phase final time
     _define_step_times(self, dynamics_step_time: list, ode_solver_steps: int,
         keep_intermediate_points: bool = None, continuous: bool = True,
-        is_direct_collocation: bool = None, include_starting_collocation_point: bool = False) -> np.ndarray
+        is_direct_collocation: bool = None, duplicate_collocation_starting_point: bool = False) -> np.ndarray
         Define the time steps for the integration of the whole phase
     _define_step_times(self, dynamics_step_time: list, ode_solver_steps: int,
         keep_intermediate_points: bool = None, continuous: bool = True,
-        is_direct_collocation: bool = None, include_starting_collocation_point: bool = False) -> np.ndarray
+        is_direct_collocation: bool = None, duplicate_collocation_starting_point: bool = False) -> np.ndarray
         Define the time steps for the integration of the whole phase
     _complete_controls(self, controls: dict[str, np.ndarray]) -> dict[str, np.ndarray]
         Controls don't necessarily have dimensions that matches the states. This method aligns them
@@ -313,15 +313,15 @@ class SimplifiedNLP:
         np.ndarray
         """
         is_direct_collocation = self.ode_solver.is_direct_collocation
-        include_starting_collocation_point = False
+        duplicate_collocation_starting_point = False
         if is_direct_collocation:
-            include_starting_collocation_point = self.ode_solver.include_starting_collocation_point
+            duplicate_collocation_starting_point = self.ode_solver.duplicate_collocation_starting_point
 
         step_times = self._define_step_times(
             dynamics_step_time=self.dynamics[0].step_time,
             ode_solver_steps=self.ode_solver.steps,
             is_direct_collocation=is_direct_collocation,
-            include_starting_collocation_point=include_starting_collocation_point,
+            duplicate_collocation_starting_point=duplicate_collocation_starting_point,
             keep_intermediate_points=keep_intermediate_points,
             continuous=shooting_type == Shooting.SINGLE,
         )
@@ -356,7 +356,7 @@ class SimplifiedNLP:
         keep_intermediate_points: bool = None,
         continuous: bool = True,
         is_direct_collocation: bool = None,
-        include_starting_collocation_point: bool = False,
+        duplicate_collocation_starting_point: bool = False,
     ) -> np.ndarray:
         """
         Define the time steps for the integration of the whole phase
@@ -375,7 +375,7 @@ class SimplifiedNLP:
             arrival node and the beginning of the next one are expected to be almost equal when the problem converged
         is_direct_collocation: bool
             If the ode solver is direct collocation
-        include_starting_collocation_point
+        duplicate_collocation_starting_point
             If the ode solver is direct collocation and an additional collocation point at the shooting node was used
 
         Returns
@@ -392,7 +392,7 @@ class SimplifiedNLP:
             if keep_intermediate_points:
                 step_times = np.array(dynamics_step_time + [1])
 
-                if include_starting_collocation_point:
+                if duplicate_collocation_starting_point:
                     step_times = np.array([0] + step_times)
             else:
                 step_times = np.array(dynamics_step_time + [1])[[0, -1]]

--- a/bioptim/optimization/stochastic_optimal_control_program.py
+++ b/bioptim/optimization/stochastic_optimal_control_program.py
@@ -321,7 +321,7 @@ class StochasticOptimalControlProgram(OptimalControlProgram):
             return OdeSolver.COLLOCATION(
                 method=self.problem_type.method,
                 polynomial_degree=self.problem_type.polynomial_degree,
-                include_starting_collocation_point=True,
+                duplicate_collocation_starting_point=True,
             )
         else:
             raise RuntimeError("Wrong choice of problem_type, you must choose one of the SocpType.")
@@ -372,7 +372,7 @@ def _check_has_no_ode_solver_defined(**kwargs):
             "OdeSolver.COLLOCATION("
             "method=problem_type.method, "
             "polynomial_degree=problem_type.polynomial_degree, "
-            "include_starting_collocation_point=True"
+            "duplicate_collocation_starting_point=True"
             ")"
         )
 


### PR DESCRIPTION
While refactoring this weekend, including_starting_collocation_point seemed hard to understand for me. 

I propose renaming :
"duplicate_collocation_starting_point" which emphasize more what it does.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/bioptim/796)
<!-- Reviewable:end -->
