### PR TITLE
Fixing error in set_friction_coefficients

### DIFF
--- a/bioptim/models/biorbd/biorbd_model.py
+++ b/bioptim/models/biorbd/biorbd_model.py
@@ -106,7 +106,7 @@ class BiorbdModel:
     def set_friction_coefficients(self, new_friction_coefficients) -> None:
         if np.any(new_friction_coefficients < 0):
             raise ValueError("Friction coefficients must be positive")
-        return self._friction_coefficients
+        self._friction_coefficients = new_friction_coefficients
 
     @property
     def gravity(self) -> Function:


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document [docs/contribution.md]?
* [ ] Have you checked to ensure there aren't other open [Pull Requests] for the same update/change?
* [ ] Have you opened/linked the issue related to your pull request?
* [ ] Have you used the tag [WIP] for on-going changes, and removed it when the pull request was ready?
* [ ] When ready to merge, have you sent a comment pinging @pariterre in it?

### New Feature Submissions:

1. [ ] Does your submission pass the tests (if not please explain why this is intended)?
2. [ ] Did you write a proper documentation (docstrings and ReadMe)
3. [ ] Have you linted your code locally prior to submission (using the command: `black . -l120 --exclude "external/*"`)?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new examples for your core changes, as applicable?
* [ ] Have you written new tests for your core changes, as applicable?

It seems to me that the set_friction_coefficients function is incorrectly implemented as it returns the parameter instead of changing it. This PR fixes that

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/bioptim/913)
<!-- Reviewable:end -->
