### PR TITLE
[RTR] Refactor and fixing bugs - list of OdeSolvers, multiphase algebraic states bounds and not on every phases.

### DIFF
--- a/bioptim/misc/options.py
+++ b/bioptim/misc/options.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import Any, Callable
 
 import numpy as np
@@ -339,7 +340,7 @@ class OptionDict(OptionList):
     def phase_duplication(self, n_phases: int):
         if self.nb_phase != 1:
             raise ValueError(f"phase_duplication is only available for n_phases=1. Got {self.nb_phase} instead.")
-        self.options = [self.options[0]] * n_phases
+        self.options = [deepcopy(self.options[0]) for _ in range(n_phases)]
 
 
 class UniquePerPhaseOptionList(OptionList):

--- a/bioptim/misc/options.py
+++ b/bioptim/misc/options.py
@@ -262,6 +262,10 @@ class OptionDict(OptionList):
         self.options = [{}]
         self.sub_type = sub_type
 
+    @property
+    def nb_phase(self):
+        return len(self.options)
+
     def add(self, *args, **kwargs):
         raise NotImplementedError("This is an abstract method")
 
@@ -331,6 +335,11 @@ class OptionDict(OptionList):
 
     def keys(self, phase: int = 0):
         return self.options[phase].keys()
+
+    def phase_duplication(self, n_phases: int):
+        if self.nb_phase != 1:
+            raise ValueError(f"phase_duplication is only available for n_phases=1. Got {self.nb_phase} instead.")
+        self.options = [self.options[0]] * n_phases
 
 
 class UniquePerPhaseOptionList(OptionList):

--- a/bioptim/optimization/non_linear_program.py
+++ b/bioptim/optimization/non_linear_program.py
@@ -238,7 +238,7 @@ class NonLinearProgram:
             return
 
         if not isinstance(bounds, BoundsList):
-            raise RuntimeError(f"{bound_name} should be built from a BoundsList")
+            raise TypeError(f"{bound_name} should be built from a BoundsList.")
 
         valid_keys = allowed_keys + ["None"]
         if not all(key in valid_keys for key in bounds.keys()):

--- a/bioptim/optimization/non_linear_program.py
+++ b/bioptim/optimization/non_linear_program.py
@@ -253,15 +253,27 @@ class NonLinearProgram:
             nlp_bounds.add(key, bounds[key], phase=0)
 
     def update_bounds_on_plots(self):
-        for key in self.states.keys():
-            if f"{key}_states" in self.plot and key in self.x_bounds.keys():
-                self.plot[f"{key}_states"].bounds = self.x_bounds[key]
-        for key in self.controls.keys():
-            if f"{key}_controls" in self.plot and key in self.u_bounds.keys():
-                self.plot[f"{key}_controls"].bounds = self.u_bounds[key]
-        for key in self.algebraic_states.keys():
-            if f"{key}_algebraic" in self.plot and key in self.a_bounds.keys():
-                self.plot[f"{key}_algebraic"].bounds = self.a_bounds[key]
+        self._update_plot_bounds(self.states.keys(), self.x_bounds, "_states")
+        self._update_plot_bounds(self.controls.keys(), self.u_bounds, "_controls")
+        self._update_plot_bounds(self.algebraic_states.keys(), self.a_bounds, "_algebraic")
+
+    def _update_plot_bounds(self, keys, bounds, suffix):
+        """
+        Helper method to update plot bounds for a given group.
+
+        Parameters
+        ----------
+        keys: list
+            The keys to update
+        bounds: BoundsList
+            The bounds to update
+        suffix: str
+            The suffix to add to the keys
+        """
+        for key in keys:
+            plot_key = f"{key}{suffix}"
+            if plot_key in self.plot and key in bounds.keys():
+                self.plot[plot_key].bounds = bounds[key]
 
     @property
     def n_states_nodes(self) -> int:

--- a/bioptim/optimization/optimal_control_program.py
+++ b/bioptim/optimization/optimal_control_program.py
@@ -511,7 +511,11 @@ class OptimalControlProgram:
             ode_solver = self._set_default_ode_solver()
 
         is_ode_solver = isinstance(ode_solver, OdeSolverBase)
-        is_list_ode_solver = all([isinstance(ode, OdeSolverBase) for ode in ode_solver])
+        is_list_ode_solver = (
+            all([isinstance(ode, OdeSolverBase) for ode in ode_solver])
+            if isinstance(ode_solver, list) or isinstance(ode_solver, tuple)
+            else False
+        )
         if not is_ode_solver and not is_list_ode_solver:
             raise RuntimeError("ode_solver should be built an instance of OdeSolver or a list of OdeSolver")
 
@@ -1076,7 +1080,7 @@ class OptimalControlProgram:
         a_bounds: BoundsList = None,
     ):
         """
-        The main user interface to add bounds in the ocp
+        The main user interface to add bounds in the ocp to nlps.
 
         Parameters
         ----------
@@ -1089,63 +1093,47 @@ class OptimalControlProgram:
         a_bounds: BoundsList
             The algebraic_states variable bounds to add
         """
-        for i in range(self.n_phases):
-            if x_bounds is not None:
-                if not isinstance(x_bounds, BoundsList):
-                    raise RuntimeError("x_bounds should be built from a BoundsList")
-                origin_phase = 0 if len(x_bounds) == 1 else i
-                for key in x_bounds[origin_phase].keys():
-                    if key not in self.nlp[i].states.keys() + ["None"]:
-                        raise ValueError(
-                            f"{key} is not a state variable, please check for typos in the declaration of x_bounds"
-                        )
-                    self.nlp[i].x_bounds.add(key, x_bounds[origin_phase][key], phase=0)
+        # Assume when only one phase is defined, the user wants to apply the same bounds to all phases
+        if x_bounds is not None:
+            if not isinstance(x_bounds, BoundsList):
+                raise RuntimeError("x_bounds should be built from a BoundsList")
+            if len(x_bounds) == 1 and self.n_phases > 1:
+                x_bounds.phase_duplication(self.n_phases)
 
-            if u_bounds is not None:
-                if not isinstance(u_bounds, BoundsList):
-                    raise RuntimeError("u_bounds should be built from a BoundsList")
-                for key in u_bounds.keys():
-                    if key not in self.nlp[i].controls.keys() + ["None"]:
-                        raise ValueError(
-                            f"{key} is not a control variable, please check for typos in the declaration of u_bounds"
-                        )
-                    origin_phase = 0 if len(u_bounds) == 1 else i
-                    self.nlp[i].u_bounds.add(key, u_bounds[origin_phase][key], phase=0)
+        if u_bounds is not None:
+            if not isinstance(u_bounds, BoundsList):
+                raise RuntimeError("u_bounds should be built from a BoundsList")
+            if len(u_bounds) == 1 and self.n_phases > 1:
+                u_bounds.phase_duplication(self.n_phases)
 
-            if a_bounds is not None:
-                if not isinstance(a_bounds, BoundsList):
-                    raise RuntimeError("a_bounds should be built from a BoundsList")
-                origin_phase = 0 if len(a_bounds) == 1 else i
-                if origin_phase + 1 > len(a_bounds):
-                    continue  # Trying to skip the phases if it doesn't have any algebraic states
-                for key in a_bounds[origin_phase].keys():
-                    if key not in self.nlp[i].algebraic_states.keys() + ["None"]:
-                        raise ValueError(
-                            f"{key} is not an algebraic variable, please check for typos in the declaration of a_bounds"
-                        )
-                    origin_phase = 0 if len(a_bounds) == 1 else i
-                    self.nlp[i].a_bounds.add(key, a_bounds[origin_phase][key], phase=0)
+        if a_bounds is not None:
+            if not isinstance(a_bounds, BoundsList):
+                raise RuntimeError("a_bounds should be built from a BoundsList")
+            if len(a_bounds) == 1 and self.n_phases > 1:
+                a_bounds.phase_duplication(self.n_phases)
+
+        for p, nlp in enumerate(self.nlp):
+            x_bounds_p = x_bounds[p] if x_bounds else None
+            u_bounds_p = u_bounds[p] if u_bounds else None
+            a_bounds_p = a_bounds[p] if a_bounds else None
+            nlp.update_bounds(x_bounds_p, u_bounds_p, a_bounds_p)
 
         if parameter_bounds is not None:
             if not isinstance(parameter_bounds, BoundsList):
                 raise RuntimeError("parameter_bounds should be built from a BoundsList")
+            valid_keys = self.parameters.keys() + ["None"]
+            if not all([key in valid_keys for key in parameter_bounds.keys()]):
+                raise ValueError(
+                    f"Please check for typos in the declaration of parameter_bounds. "
+                    f"Here are declared keys: {list(parameter_bounds.keys())}. "
+                    f"Available keys are: {valid_keys}."
+                )
+
             for key in parameter_bounds.keys():
-                if key not in self.parameters.keys() + ["None"]:
-                    raise ValueError(
-                        f"{key} is not a parameter variable, please check for typos in the declaration of parameter_bounds"
-                    )
                 self.parameter_bounds.add(key, parameter_bounds[key], phase=0)
 
         for nlp in self.nlp:
-            for key in nlp.states.keys():
-                if f"{key}_states" in nlp.plot and key in nlp.x_bounds.keys():
-                    nlp.plot[f"{key}_states"].bounds = nlp.x_bounds[key]
-            for key in nlp.controls.keys():
-                if f"{key}_controls" in nlp.plot and key in nlp.u_bounds.keys():
-                    nlp.plot[f"{key}_controls"].bounds = nlp.u_bounds[key]
-            for key in nlp.algebraic_states.keys():
-                if f"{key}_algebraic" in nlp.plot and key in nlp.a_bounds.keys():
-                    nlp.plot[f"{key}_algebraic"].bounds = nlp.a_bounds[key]
+            nlp.update_bounds_on_plots()
 
     def update_initial_guess(
         self,

--- a/bioptim/optimization/optimal_control_program.py
+++ b/bioptim/optimization/optimal_control_program.py
@@ -509,8 +509,11 @@ class OptimalControlProgram:
 
         if ode_solver is None:
             ode_solver = self._set_default_ode_solver()
-        elif not isinstance(ode_solver, OdeSolverBase):
-            raise RuntimeError("ode_solver should be built an instance of OdeSolver")
+
+        is_ode_solver = isinstance(ode_solver, OdeSolverBase)
+        is_list_ode_solver = all([isinstance(ode, OdeSolverBase) for ode in ode_solver])
+        if not is_ode_solver and not is_list_ode_solver:
+            raise RuntimeError("ode_solver should be built an instance of OdeSolver or a list of OdeSolver")
 
         if not isinstance(use_sx, bool):
             raise RuntimeError("use_sx should be a bool")

--- a/bioptim/optimization/optimal_control_program.py
+++ b/bioptim/optimization/optimal_control_program.py
@@ -1116,6 +1116,8 @@ class OptimalControlProgram:
                 if not isinstance(a_bounds, BoundsList):
                     raise RuntimeError("a_bounds should be built from a BoundsList")
                 origin_phase = 0 if len(a_bounds) == 1 else i
+                if origin_phase + 1 > len(a_bounds):
+                    continue  # Trying to skip the phases if it doesn't have any algebraic states
                 for key in a_bounds[origin_phase].keys():
                     if key not in self.nlp[i].algebraic_states.keys() + ["None"]:
                         raise ValueError(
@@ -1204,6 +1206,8 @@ class OptimalControlProgram:
                 if not isinstance(a_init, InitialGuessList):
                     raise RuntimeError("a_init should be built from a InitialGuessList")
                 origin_phase = 0 if len(a_init) == 1 else i
+                if origin_phase + 1 > len(a_init):
+                    continue  # Trying to skip the phases if it doesn't have any algebraic states
                 for key in a_init[origin_phase].keys():
                     if key not in self.nlp[i].algebraic_states.keys() + ["None"]:
                         raise ValueError(

--- a/bioptim/optimization/optimal_control_program.py
+++ b/bioptim/optimization/optimal_control_program.py
@@ -1112,7 +1112,8 @@ class OptimalControlProgram:
             if a_bounds is not None:
                 if not isinstance(a_bounds, BoundsList):
                     raise RuntimeError("a_bounds should be built from a BoundsList")
-                for key in a_bounds.keys():
+                origin_phase = 0 if len(a_bounds) == 1 else i
+                for key in a_bounds[origin_phase].keys():
                     if key not in self.nlp[i].algebraic_states.keys() + ["None"]:
                         raise ValueError(
                             f"{key} is not an algebraic variable, please check for typos in the declaration of a_bounds"

--- a/tests/shard1/test_prepare_all_examples.py
+++ b/tests/shard1/test_prepare_all_examples.py
@@ -302,6 +302,18 @@ def test__getting_started__example_multiphase_different_ode_solvers():
         ode_solver=[OdeSolver.RK1(), OdeSolver.RK4(), OdeSolver.COLLOCATION()],
     )
 
+    with pytest.raises(
+        RuntimeError,
+        match="ode_solver should be built an instance of OdeSolver or a list of OdeSolver",
+    ):
+        ocp_module.prepare_ocp(
+            biorbd_model_path=bioptim_folder + "/models/cube.bioMod",
+            long_optim=True,
+            phase_dynamics=PhaseDynamics.SHARED_DURING_THE_PHASE,
+            expand_dynamics=False,
+            ode_solver=["hello", "world", "there"],
+        )
+
 
 # todo: Add example_multistart.py?
 

--- a/tests/shard1/test_prepare_all_examples.py
+++ b/tests/shard1/test_prepare_all_examples.py
@@ -1,9 +1,7 @@
-import os
-
-from bioptim import InterpolationType, PhaseDynamics
 import numpy as np
 import pytest
 
+from bioptim import InterpolationType, PhaseDynamics, OdeSolver
 from ..utils import TestUtils
 
 
@@ -288,6 +286,20 @@ def test__getting_started__example_multiphase():
         long_optim=True,
         phase_dynamics=PhaseDynamics.SHARED_DURING_THE_PHASE,
         expand_dynamics=False,
+    )
+
+
+def test__getting_started__example_multiphase_different_ode_solvers():
+    from bioptim.examples.getting_started import example_multiphase as ocp_module
+
+    bioptim_folder = TestUtils.module_folder(ocp_module)
+
+    ocp_module.prepare_ocp(
+        biorbd_model_path=bioptim_folder + "/models/cube.bioMod",
+        long_optim=True,
+        phase_dynamics=PhaseDynamics.SHARED_DURING_THE_PHASE,
+        expand_dynamics=False,
+        ode_solver=[OdeSolver.RK1(), OdeSolver.RK4(), OdeSolver.COLLOCATION()],
     )
 
 

--- a/tests/shard4/test_update_bounds_and_init.py
+++ b/tests/shard4/test_update_bounds_and_init.py
@@ -69,6 +69,19 @@ def test_double_update_bounds_and_init(phase_dynamics):
     x_bounds = BoundsList()
     x_bounds["q"] = -2.0 * np.ones((nq, 1)), 2.0 * np.ones((nq, 1))
     x_bounds["qdot"] = -2.0 * np.ones((nq, 1)), 2.0 * np.ones((nq, 1))
+    assert x_bounds.nb_phase == 1
+
+    x_bounds_test = BoundsList()
+    x_bounds_test["q"] = -2.0 * np.ones((nq, 1)), 2.0 * np.ones((nq, 1))
+    x_bounds_test["qdot"] = -2.0 * np.ones((nq, 1)), 2.0 * np.ones((nq, 1))
+    x_bounds_test.phase_duplication(10)
+    assert x_bounds_test.nb_phase == 10
+    for p in range(9):
+        assert list(x_bounds_test[p].keys()) == list(x_bounds_test[p + 1].keys())
+        for key in x_bounds_test[p].keys():
+            npt.assert_almost_equal(x_bounds_test[p][key].min, x_bounds_test[p + 1][key].min)
+            npt.assert_almost_equal(x_bounds_test[p][key].max, x_bounds_test[p + 1][key].max)
+
     u_bounds = BoundsList()
     u_bounds["tau"] = -4.0 * np.ones((nq, 1)), 4.0 * np.ones((nq, 1))
     ocp.update_bounds(x_bounds=x_bounds)
@@ -82,6 +95,8 @@ def test_double_update_bounds_and_init(phase_dynamics):
     x_init = InitialGuessList()
     x_init["q"] = 0.25 * np.ones((nq, 1))
     x_init["qdot"] = 0.25 * np.ones((nq, 1))
+    assert x_init.nb_phase == 1
+
     u_init = InitialGuessList()
     u_init["tau"] = -0.25 * np.ones((nq, 1))
     ocp.update_initial_guess(x_init, u_init)

--- a/tests/shard4/test_update_bounds_and_init.py
+++ b/tests/shard4/test_update_bounds_and_init.py
@@ -115,10 +115,20 @@ def test_double_update_bounds_and_init(phase_dynamics):
         ocp.update_initial_guess(x_bounds, u_bounds)
     with pytest.raises(RuntimeError, match="u_init should be built from a InitialGuessList"):
         ocp.update_initial_guess(None, u_bounds)
+    with pytest.raises(RuntimeError, match="a_init should be built from a InitialGuessList"):
+        ocp.update_initial_guess(None, None, None, x_bounds)
+    with pytest.raises(RuntimeError, match="parameter_init should be built from a InitialGuessList"):
+        ocp.update_initial_guess(None, None, x_bounds)
+    with pytest.raises(RuntimeError, match="u_init should be built from a InitialGuessList"):
+        ocp.update_initial_guess(None, u_bounds)
     with pytest.raises(RuntimeError, match="x_bounds should be built from a BoundsList"):
         ocp.update_bounds(x_init, u_init)
     with pytest.raises(RuntimeError, match="u_bounds should be built from a BoundsList"):
         ocp.update_bounds(None, u_init)
+    with pytest.raises(RuntimeError, match="parameter_bounds should be built from a BoundsList"):
+        ocp.update_bounds(None, None, x_init)
+    with pytest.raises(RuntimeError, match="a_bounds should be built from a BoundsList"):
+        ocp.update_bounds(x_bounds, u_bounds, None, u_init)
     with pytest.raises(
         ValueError,
         match=re.escape(

--- a/tests/shard4/test_update_bounds_and_init.py
+++ b/tests/shard4/test_update_bounds_and_init.py
@@ -1,7 +1,10 @@
-import pytest
+import re
+
 import numpy as np
 import numpy.testing as npt
+import pytest
 from casadi import MX
+
 from bioptim import (
     BiorbdModel,
     OptimalControlProgram,
@@ -16,7 +19,6 @@ from bioptim import (
     PhaseDynamics,
     VariableScaling,
 )
-
 from tests.utils import TestUtils
 
 
@@ -95,13 +97,19 @@ def test_double_update_bounds_and_init(phase_dynamics):
     with pytest.raises(RuntimeError, match="u_bounds should be built from a BoundsList"):
         ocp.update_bounds(None, u_init)
     with pytest.raises(
-        ValueError, match="bad_key is not a state variable, please check for typos in the declaration of x_bounds"
+        ValueError,
+        match=re.escape(
+            "Please check for typos in the declaration of x_bounds. Here are declared keys: ['bad_key']. Available keys are: ['q', 'qdot']."
+        ),
     ):
         x_bounds = BoundsList()
         x_bounds.add("bad_key", [1, 2])
         ocp.update_bounds(x_bounds, u_bounds)
     with pytest.raises(
-        ValueError, match="bad_key is not a control variable, please check for typos in the declaration of u_bounds"
+        ValueError,
+        match=re.escape(
+            "Please check for typos in the declaration of u_bounds. Here are declared keys: ['bad_key']. Available keys are: ['tau']."
+        ),
     ):
         x_bounds = BoundsList()
         x_bounds["q"] = -np.ones((nq, 1)), np.ones((nq, 1))

--- a/tests/shard4/test_variable_time.py
+++ b/tests/shard4/test_variable_time.py
@@ -1,7 +1,7 @@
 import numpy as np
 import numpy.testing as npt
-from casadi import MX
 import pytest
+from casadi import MX
 
 from bioptim import (
     BiorbdModel,
@@ -25,7 +25,6 @@ from bioptim import (
     VariableScaling,
 )
 from bioptim.optimization.solution.solution import Solution
-
 from tests.utils import TestUtils
 
 
@@ -82,6 +81,7 @@ def prepare_ocp(phase_time_constraint, use_parameter, phase_dynamics):
     x_bounds.add("qdot", bio_model[1].bounds_from_ranges("qdot"), phase=1)
     x_bounds.add("q", bio_model[2].bounds_from_ranges("q"), phase=2)
     x_bounds.add("qdot", bio_model[2].bounds_from_ranges("qdot"), phase=2)
+    assert x_bounds.nb_phase == n_phases
 
     for bounds in x_bounds:
         bounds["q"][1, [0, -1]] = 0


### PR DESCRIPTION
- The checks of ode solvers were not allowing to use different solvers for each phase. Added a test to preserve that feature.
- The bounds of algebraic states were not multiphase.
- Assuming bounds are the same over every phase when length of a BoundList =1 made clear by refactoring, 

Essentially, I'm preparing the field for bounds not defined for different phases. I have a problem where algebraic states bounds existing only on 3/5 phases.

Sub-step for #907, to decrease the cognitive load of the review. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/bioptim/914)
<!-- Reviewable:end -->
