### PR TITLE
[RTM] docs: holonomic constraints in the solver within an example

### DIFF
--- a/bioptim/examples/holonomic_constraints/custom_dynamics.py
+++ b/bioptim/examples/holonomic_constraints/custom_dynamics.py
@@ -18,8 +18,8 @@ def constraint_holonomic_end(
     controllers: PenaltyController,
 ):
     """
-    Minimize the distance between two markers
-    By default this function is quadratic, meaning that it minimizes distance between them.
+    The custom constraint function that provides the holonomic constraints at the end node
+    This function is used to compute the holonomic constraints at the end node of the phase.
 
     Parameters
     ----------
@@ -42,8 +42,9 @@ def constraint_holonomic(
     controllers: PenaltyController,
 ):
     """
-    Minimize the distance between two markers
-    By default this function is quadratic, meaning that it minimizes distance between them.
+    Applies the holonomic constraints on each collocation node into the constraint set of solver.
+    The holonomic constraints are not any more embedded in the equations of motion,
+    but rather in the constraint set of the solver.
 
     Parameters
     ----------

--- a/bioptim/examples/holonomic_constraints/custom_dynamics.py
+++ b/bioptim/examples/holonomic_constraints/custom_dynamics.py
@@ -42,7 +42,8 @@ def constraint_holonomic(
     controllers: PenaltyController,
 ):
     """
-    Applies the holonomic constraints on each collocation node into the constraint set of solver.
+    The custom constraint function that provides the holonomic constraints at each collocation node.
+    This function is used to add the holonomic constraints to the solver's constraint set.
     Please note that the holonomic constraints are NOT embedded in the equations of motion,
     but rather in the constraint set of the solver.
 

--- a/bioptim/examples/holonomic_constraints/custom_dynamics.py
+++ b/bioptim/examples/holonomic_constraints/custom_dynamics.py
@@ -19,7 +19,7 @@ def constraint_holonomic_end(
 ):
     """
     The custom constraint function that provides the holonomic constraints at the end node
-    This function is used to compute the holonomic constraints at the end node of the phase.
+    This function is used to compute the holonomic constraints at the end node of the phase because the last interval does not have cx_intermediates_list variables.
 
     Parameters
     ----------

--- a/bioptim/examples/holonomic_constraints/custom_dynamics.py
+++ b/bioptim/examples/holonomic_constraints/custom_dynamics.py
@@ -43,7 +43,7 @@ def constraint_holonomic(
 ):
     """
     Applies the holonomic constraints on each collocation node into the constraint set of solver.
-    The holonomic constraints are not any more embedded in the equations of motion,
+    Please note that the holonomic constraints are NOT embedded in the equations of motion,
     but rather in the constraint set of the solver.
 
     Parameters


### PR DESCRIPTION
Refines the descriptions of the holonomic constraint functions to better reflect their purpose and usage within the solver.

- Explains that holonomic constraints are added directly to the solver's constraint set, rather than being embedded in the equations of motion.
- Details the purpose of the end node constraint function.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/bioptim/989)
<!-- Reviewable:end -->
