### PR TITLE
[RTR] Corrected variable name in pendulum example of ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,7 +569,7 @@ x_bounds = BoundsList()
 x_bounds["q"] = bio_model.bounds_from_ranges("q")
 x_bounds["q"][:, [0, -1]] = 0
 x_bounds["q"][1, -1] = 3.14
-x_bounds["dot"] = bio_model.bounds_from_ranges("qdot")
+x_bounds["qdot"] = bio_model.bounds_from_ranges("qdot")
 x_bounds["qdot"][:, [0, -1]] = 0
 
 u_bounds = BoundsList()


### PR DESCRIPTION
Tried the pendulum example given and didn't work ; Replaced x_bounds["dot"] by x_bounds["qdot"] like it was written on the tutorial just before.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/bioptim/992)
<!-- Reviewable:end -->
