### PR TITLE
[RTM] fix: example holonomic double pendulum

### DIFF
--- a/bioptim/examples/holonomic_constraints/two_pendulums.py
+++ b/bioptim/examples/holonomic_constraints/two_pendulums.py
@@ -62,7 +62,6 @@ def compute_all_states(sol, bio_model: HolonomicTorqueBiorbdModel):
 
     q_v_init = DM.zeros(bio_model.nb_dependent_joints, n)
     for i in range(n):
-        print(i)
         q_v_i = bio_model.compute_q_v()(states["q_u"][:, i], q_v_init[:, i]).toarray()
         q[:, i] = bio_model.state_from_partition(states["q_u"][:, i][:, np.newaxis], q_v_i).toarray().squeeze()
         qdot[:, i] = bio_model.compute_qdot()(q[:, i], states["qdot_u"][:, i]).toarray().squeeze()


### PR DESCRIPTION
Rapid Maintenance on the holonomic example, indexes were broken.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/bioptim/1004)
<!-- Reviewable:end -->
