### PR TITLE
macos_online_fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -788,8 +788,9 @@ One can refer to their respective solver's documentation to know which options e
 The `show_online_optim` parameter can be set to `True` so the graphs nicely update during the optimization with the default values.
 One can also directly declare `online_optim` as an `OnlineOptim` parameter to customize the behavior of the plotter. 
 Note that `show_online_optim` and `online_optim` are mutually exclusive.
-Please also note that `OnlineOptim.MULTIPROCESS` is not available on Windows and only none of them are available on Macos. 
-To see how to run the server on Windows, please refer to the `getting_started/pendulum.py` example.
+Please also note that `OnlineOptim.MULTIPROCESS` is not available on Windows or Macos.
+On Macos, the default backend is `OnlineOptim.MULTIPROCESS_SERVER`, while `OnlineOptim.SERVER` remains available if one wants to start `resources/plotting_server.py` manually.
+To see how to run the server explicitly, please refer to the `resources/plotting_server.py` example.
 It is expected to slow down the optimization a bit. 
 `show_options` can be also passed as a dict to the plotter to customize the plotter's behavior.
 If `online_optim` is set to `SERVER`, then a server must be started manually by instantiating an `PlottingServer` class (see `ressources/plotting_server.py`).
@@ -1720,7 +1721,7 @@ The type of online plotter to use.
 
 The accepted values are:
 NONE: No online plotter.
-DEFAULT: Use the default online plotter depending on the OS (MULTIPROCESS on Linux, MULTIPROCESS_SERVER on Windows and NONE on MacOS).
+DEFAULT: Use the default online plotter depending on the OS (MULTIPROCESS on Linux, MULTIPROCESS_SERVER on Windows and macOS).
 MULTIPROCESS: The online plotter is in a separate process.
 SERVER: The online plotter is in a separate server.
 MULTIPROCESS_SERVER: The online plotter using the server automatically setup on a separate process.

--- a/README.md
+++ b/README.md
@@ -796,7 +796,7 @@ It is expected to slow down the optimization a bit.
 If `online_optim` is set to `SERVER`, then a server must be started manually by instantiating an `PlottingServer` class (see `ressources/plotting_server.py`).
 The following keys are additional options when using `OnlineOptim.SERVER` and `OnlineOptim.MULTIPROCESS_SERVER`:
   - `host`: the host to use (default is `localhost`)
-  - `port`: the port to use (default is `5030`)
+  - `port`: the port to use (default is `5030` for `OnlineOptim.SERVER` and a random available port for `OnlineOptim.MULTIPROCESS_SERVER`)
 
 If you want to see IPOPT's iterations over the course of the resolution of your opc, it is possible using the following:
 ```python    

--- a/bioptim/examples/getting_started/basic_ocp.py
+++ b/bioptim/examples/getting_started/basic_ocp.py
@@ -156,8 +156,8 @@ def main():
     ocp.print(to_console=False, to_graph=False)
 
     # --- Solve the ocp --- #
-    # Default is OnlineOptim.MULTIPROCESS on Linux, OnlineOptim.MULTIPROCESS_SERVER on Windows and None on MacOS
-    # To see the graphs on MacOS, one must run the server manually (see resources/plotting_server.py)
+    # Default is OnlineOptim.MULTIPROCESS on Linux and OnlineOptim.MULTIPROCESS_SERVER on Windows and MacOS
+    # On MacOS, OnlineOptim.SERVER remains available if you prefer to start resources/plotting_server.py manually
     solver = Solver.IPOPT(online_optim=OnlineOptim.DEFAULT)
 
     # # Show the constraints Jacobian sparsity
@@ -183,7 +183,13 @@ def main():
     # --- Animate the solution --- #
     viewer = "bioviz"
     # viewer = "pyorerun"
-    sol.animate(n_frames=0, viewer=viewer, show_now=True)
+    try:
+        sol.animate(n_frames=0, viewer=viewer, show_now=True)
+    except RuntimeError as exc:
+        if viewer == "bioviz" and "bioviz must be install" in str(exc):
+            print("Animation skipped because bioviz is not installed.")
+        else:
+            raise
 
     # # --- Saving the solver's output after the optimization --- #
     # Here is an example of how we recommend to save the solution. Please note that sol.ocp is not picklable and that sol will be loaded using the current bioptim version, not the version at the time of the generation of the results.

--- a/bioptim/examples/getting_started/basic_ocp.py
+++ b/bioptim/examples/getting_started/basic_ocp.py
@@ -156,8 +156,7 @@ def main():
     ocp.print(to_console=False, to_graph=False)
 
     # --- Solve the ocp --- #
-    # Default is OnlineOptim.MULTIPROCESS on Linux and OnlineOptim.MULTIPROCESS_SERVER on Windows and MacOS
-    # On MacOS, OnlineOptim.SERVER remains available if you prefer to start resources/plotting_server.py manually
+    # Default is OnlineOptim.MULTIPROCESS_SERVER on all platforms.
     solver = Solver.IPOPT(online_optim=OnlineOptim.DEFAULT)
 
     # # Show the constraints Jacobian sparsity
@@ -180,19 +179,16 @@ def main():
     sol.print_cost()
     # sol.graphs(show_bounds=True, save_name="results.png")
 
-    # --- Animate the solution --- #
-    viewer = "bioviz"
-    # viewer = "pyorerun"
-    try:
-        sol.animate(n_frames=0, viewer=viewer, show_now=True)
-    except RuntimeError as exc:
-        if viewer == "bioviz" and "bioviz must be install" in str(exc):
-            print("Animation skipped because bioviz is not installed.")
-        else:
-            raise
+    # # --- Animate the solution --- #
+    # # To animate the solution, we can use the animate function. Uncomment the current block
+    # # to see the animation.
+    # # 'bioviz' must be installed to use the bioviz viewer.
+    # # Similarly, 'pyorerun' must be installed to use the pyorerun viewer.
+    # viewer = "bioviz"  # "pyorerun"
+    # sol.animate(n_frames=0, viewer=viewer, show_now=True)
 
     # # --- Saving the solver's output after the optimization --- #
-    # Here is an example of how we recommend to save the solution. Please note that sol.ocp is not picklable and that sol will be loaded using the current bioptim version, not the version at the time of the generation of the results.
+    # # Here is an example of how we recommend to save the solution. Please note that sol.ocp is not picklable and that sol will be loaded using the current bioptim version, not the version at the time of the generation of the results.
     # import pickle
     # import git
     # from datetime import date

--- a/bioptim/gui/online_callback_multiprocess_server.py
+++ b/bioptim/gui/online_callback_multiprocess_server.py
@@ -1,4 +1,5 @@
 from multiprocessing import Process
+import socket
 
 from .online_callback_server import PlottingServer, OnlineCallbackServer
 
@@ -15,6 +16,13 @@ def _start_server_internal(**kwargs):
     PlottingServer(**kwargs)
 
 
+def _find_available_tcp_port(host: str | None) -> int:
+    bind_host = host if host else "localhost"
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((bind_host, 0))
+        return sock.getsockname()[1]
+
+
 class OnlineCallbackMultiprocessServer(OnlineCallbackServer):
     def __init__(self, *args, **kwargs):
         """
@@ -26,6 +34,9 @@ class OnlineCallbackMultiprocessServer(OnlineCallbackServer):
         """
         host = kwargs["host"] if "host" in kwargs else None
         port = kwargs["port"] if "port" in kwargs else None
+        if port is None:
+            port = _find_available_tcp_port(host)
+            kwargs["port"] = port
         log_level = None
         if "log_level" in kwargs:
             log_level = kwargs["log_level"]

--- a/bioptim/gui/online_callback_multiprocess_server.py
+++ b/bioptim/gui/online_callback_multiprocess_server.py
@@ -3,6 +3,8 @@ import socket
 
 from .online_callback_server import PlottingServer, OnlineCallbackServer
 
+_DEFAULT_HOST = "localhost"
+
 
 def _start_server_internal(**kwargs):
     """
@@ -16,10 +18,9 @@ def _start_server_internal(**kwargs):
     PlottingServer(**kwargs)
 
 
-def _find_available_tcp_port(host: str | None) -> int:
-    bind_host = host if host else "localhost"
+def _find_available_tcp_port(host: str) -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind((bind_host, 0))
+        sock.bind((host, 0))
         return sock.getsockname()[1]
 
 
@@ -32,11 +33,12 @@ class OnlineCallbackMultiprocessServer(OnlineCallbackServer):
         ----------
         Same as PlottingServer
         """
-        host = kwargs["host"] if "host" in kwargs else None
-        port = kwargs["port"] if "port" in kwargs else None
-        if port is None:
-            port = _find_available_tcp_port(host)
-            kwargs["port"] = port
+        host = kwargs["host"] if "host" in kwargs else _DEFAULT_HOST
+        port = _find_available_tcp_port(host) if "port" not in kwargs or kwargs["port"] is None else kwargs["port"]
+
+        kwargs["host"] = host
+        kwargs["port"] = port
+
         log_level = None
         if "log_level" in kwargs:
             log_level = kwargs["log_level"]

--- a/bioptim/gui/online_callback_server.py
+++ b/bioptim/gui/online_callback_server.py
@@ -485,7 +485,8 @@ class OnlineCallbackServer(OnlineCallbackAbstract):
 
         self._host: Str = host if host else _DEFAULT_HOST
         self._port: Int = port if port else _DEFAULT_PORT
-        self._socket: socket.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._socket: socket.socket | None = None
+        self._reset_client_socket()
 
         self._should_wait_ok_to_client_on_new_data: Bool = platform.system() == "Darwin"
 
@@ -501,6 +502,14 @@ class OnlineCallbackServer(OnlineCallbackAbstract):
             )
 
         self._initialize_connexion(**show_options)
+
+    def _reset_client_socket(self) -> None:
+        if self._socket is not None:
+            try:
+                self._socket.close()
+            except OSError:
+                pass
+        self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
     def _initialize_connexion(self, retries: Int = 0, **show_options) -> None:
         """
@@ -522,10 +531,11 @@ class OnlineCallbackServer(OnlineCallbackAbstract):
             if retries > 5:
                 raise RuntimeError(
                     "Could not connect to the plotter server, make sure it is running by calling 'PlottingServer()' on "
-                    "another python instance or allowing for automatic start (Linux or Windows) of the server setting "
+                    "another python instance or allowing for automatic start (Linux, Windows or macOS) of the server setting "
                     "the online_option to 'OnlineOptim.MULTIPROCESS_SERVER' when instantiating your solver."
                 )
             else:
+                self._reset_client_socket()
                 time.sleep(1)
                 return self._initialize_connexion(retries + 1, **show_options)
 

--- a/bioptim/gui/online_callback_server.py
+++ b/bioptim/gui/online_callback_server.py
@@ -17,6 +17,7 @@ from ..optimization.optimization_vector import OptimizationVectorHelper
 from ..misc.parameters_types import (
     Bool,
     Int,
+    Float,
     Str,
     Bytes,
     StrOptional,

--- a/bioptim/gui/plot.py
+++ b/bioptim/gui/plot.py
@@ -1185,8 +1185,13 @@ class PlotOcp:
                         y_min = np.inf
                         for p in ax.get_children():
                             if isinstance(p, lines.Line2D):
-                                y_min = min(y_min, np.nanmin(p.get_ydata()))
-                                y_max = max(y_max, np.nanmax(p.get_ydata()))
+                                y_data = np.asarray(p.get_ydata())
+                                if y_data.size == 0 or np.isnan(y_data).all():
+                                    continue
+                                y_min = min(y_min, np.nanmin(y_data))
+                                y_max = max(y_max, np.nanmax(y_data))
+                        if not np.isfinite(y_min) or not np.isfinite(y_max):
+                            continue
                         ax.set_ylim(self._compute_ylim(y_min, y_max, 1.25))
 
         for p in self.plots_vertical_lines:

--- a/bioptim/gui/plot.py
+++ b/bioptim/gui/plot.py
@@ -1190,8 +1190,13 @@ class PlotOcp:
                         y_min = np.inf
                         for p in ax.get_children():
                             if isinstance(p, lines.Line2D):
-                                y_min = min(y_min, np.nanmin(p.get_ydata()))
-                                y_max = max(y_max, np.nanmax(p.get_ydata()))
+                                y_data = np.asarray(p.get_ydata())
+                                if y_data.size == 0 or np.isnan(y_data).all():
+                                    continue
+                                y_min = min(y_min, np.nanmin(y_data))
+                                y_max = max(y_max, np.nanmax(y_data))
+                        if not np.isfinite(y_min) or not np.isfinite(y_max):
+                            continue
                         ax.set_ylim(self._compute_ylim(y_min, y_max, 1.25))
 
         for p in self.plots_vertical_lines:

--- a/bioptim/interfaces/interface_utils.py
+++ b/bioptim/interfaces/interface_utils.py
@@ -1,3 +1,4 @@
+import platform
 from time import perf_counter
 
 from casadi import Importer, Function, horzcat, vertcat, sum1, sum2, nlpsol, SX, MX, DM, reshape, jacobian
@@ -37,7 +38,14 @@ def generic_online_optim(interface: SolverInterface, ocp, show_options: AnyDictO
     online_optim = interface.opts.online_optim.get_default()
     if online_optim is None:
         return
-    elif online_optim == OnlineOptim.MULTIPROCESS:
+    if platform.system() == "Darwin" and online_optim == OnlineOptim.MULTIPROCESS:
+        raise NotImplementedError(
+            "online_optim MULTIPROCESS is not available on macOS. "
+            "Use OnlineOptim.MULTIPROCESS_SERVER for automatic plotting or OnlineOptim.SERVER with a manually started "
+            "PlottingServer."
+        )
+
+    if online_optim == OnlineOptim.MULTIPROCESS:
         to_call = OnlineCallbackMultiprocess
     elif online_optim == OnlineOptim.SERVER:
         to_call = OnlineCallbackServer

--- a/bioptim/misc/enums.py
+++ b/bioptim/misc/enums.py
@@ -102,7 +102,7 @@ class OnlineOptim(Enum):
     Attributes
     ----------
     NONE: No online plotting
-    DEFAULT: Default online plotting (MULTIPROCESS on Linux, MULTIPROCESS_SERVER on Windows and NONE on MacOS)
+    DEFAULT: Default online plotting (MULTIPROCESS on Linux and MULTIPROCESS_SERVER on Windows and macOS)
     MULTIPROCESS: Multiprocess online plotting
     SERVER: Server online plotting
     MULTIPROCESS_SERVER: Multiprocess server online plotting
@@ -119,7 +119,7 @@ class OnlineOptim(Enum):
 
         if platform.system() == "Linux":
             return OnlineOptim.MULTIPROCESS
-        elif platform.system() == "Windows":
+        elif platform.system() in ("Windows", "Darwin"):
             return OnlineOptim.MULTIPROCESS_SERVER
         else:
             return None

--- a/bioptim/misc/enums.py
+++ b/bioptim/misc/enums.py
@@ -117,9 +117,7 @@ class OnlineOptim(Enum):
         if self != OnlineOptim.DEFAULT:
             return self
 
-        if platform.system() == "Linux":
-            return OnlineOptim.MULTIPROCESS
-        elif platform.system() in ("Windows", "Darwin"):
+        if platform.system() in ("Linux", "Windows", "Darwin"):
             return OnlineOptim.MULTIPROCESS_SERVER
         else:
             return None

--- a/resources/plotting_server.py
+++ b/resources/plotting_server.py
@@ -7,8 +7,8 @@ If set to OnlineOptim.SERVER, then the plotting server is mandatory.
 Since the server runs usings sockets, it is possible to run the server on a different machine than the one running the
 optimization. This is useful when the optimization is run on a cluster and the plotting server is run on a local machine.
 
-On Macos, this server is necessary as it won't connect using multiprocess. One can simply run the current script on
-another terminal to access the online graphs
+On Macos, this script is still useful if one wants to force OnlineOptim.SERVER explicitly or run the plotting server
+on a different machine.
 """
 
 from bioptim import PlottingServer

--- a/tests/shard1/test_global_fatigue.py
+++ b/tests/shard1/test_global_fatigue.py
@@ -629,7 +629,7 @@ def test_fatigable_effort_torque_split(phase_dynamics):
     sol = ocp.solve()
 
     # Check objective function value
-    if platform.system() != "Windows":
+    if platform.system() == "Darwin":
         TestUtils.assert_objective_value(sol=sol, expected_value=124.09811263203727)
 
         # Check constraints

--- a/tests/shard4/test_solver_options.py
+++ b/tests/shard4/test_solver_options.py
@@ -1,5 +1,10 @@
+import pytest
+
 from bioptim import Solver
-from bioptim.misc.enums import SolverType
+from bioptim.gui.online_callback_server import OnlineCallbackServer, _ResponseHeader
+from bioptim.gui.online_callback_multiprocess_server import OnlineCallbackMultiprocessServer
+from bioptim.interfaces.interface_utils import generic_online_optim
+from bioptim.misc.enums import SolverType, OnlineOptim
 
 
 class FakeSolver:
@@ -8,6 +13,12 @@ class FakeSolver:
         options_common: dict = None,
     ):
         self.options_common = options_common
+
+
+class FakeInterface:
+    def __init__(self, online_optim):
+        self.opts = type("Opts", (), {"online_optim": online_optim})()
+        self.options_common = {}
 
 
 def test_ipopt_solver_options():
@@ -131,3 +142,150 @@ def test_ipopt_solver_options():
 
     solver.set_nlp_scaling_method("gradient-fiesta")
     assert solver.nlp_scaling_method == "gradient-fiesta"
+
+
+def test_generic_online_optim_skips_when_default_is_unavailable(monkeypatch):
+    interface = FakeInterface(OnlineOptim.DEFAULT)
+
+    monkeypatch.setattr(OnlineOptim, "get_default", lambda self: None)
+
+    generic_online_optim(interface, ocp=None)
+
+    assert interface.options_common == {}
+
+
+def test_generic_online_optim_uses_multiprocess_on_linux(monkeypatch):
+    interface = FakeInterface(OnlineOptim.DEFAULT)
+    callback = object()
+
+    monkeypatch.setattr("bioptim.misc.enums.platform.system", lambda: "Linux")
+    monkeypatch.setattr("bioptim.interfaces.interface_utils.OnlineCallbackMultiprocess", lambda *args, **kwargs: callback)
+
+    generic_online_optim(interface, ocp=None)
+
+    assert interface.options_common["iteration_callback"] is callback
+
+
+def test_generic_online_optim_uses_multiprocess_server_on_windows(monkeypatch):
+    interface = FakeInterface(OnlineOptim.DEFAULT)
+    callback = object()
+
+    monkeypatch.setattr("bioptim.misc.enums.platform.system", lambda: "Windows")
+    monkeypatch.setattr(
+        "bioptim.interfaces.interface_utils.OnlineCallbackMultiprocessServer", lambda *args, **kwargs: callback
+    )
+
+    generic_online_optim(interface, ocp=None)
+
+    assert interface.options_common["iteration_callback"] is callback
+
+
+def test_generic_online_optim_uses_multiprocess_server_on_macos(monkeypatch):
+    interface = FakeInterface(OnlineOptim.DEFAULT)
+    callback = object()
+
+    monkeypatch.setattr("bioptim.misc.enums.platform.system", lambda: "Darwin")
+    monkeypatch.setattr(
+        "bioptim.interfaces.interface_utils.OnlineCallbackMultiprocessServer", lambda *args, **kwargs: callback
+    )
+
+    generic_online_optim(interface, ocp=None)
+
+    assert interface.options_common["iteration_callback"] is callback
+
+
+def test_generic_online_optim_rejects_multiprocess_on_macos(monkeypatch):
+    interface = FakeInterface(OnlineOptim.MULTIPROCESS)
+
+    monkeypatch.setattr("bioptim.interfaces.interface_utils.platform.system", lambda: "Darwin")
+
+    with pytest.raises(NotImplementedError, match="MULTIPROCESS is not available on macOS"):
+        generic_online_optim(interface, ocp=None)
+
+
+def test_generic_online_optim_allows_server_on_macos(monkeypatch):
+    interface = FakeInterface(OnlineOptim.SERVER)
+    callback = object()
+
+    monkeypatch.setattr("bioptim.interfaces.interface_utils.platform.system", lambda: "Darwin")
+    monkeypatch.setattr("bioptim.interfaces.interface_utils.OnlineCallbackServer", lambda *args, **kwargs: callback)
+
+    generic_online_optim(interface, ocp=None)
+
+    assert interface.options_common["iteration_callback"] is callback
+
+
+def test_online_callback_server_recreates_socket_between_retries(monkeypatch):
+    class FakeSocket:
+        def __init__(self, should_fail=False):
+            self.should_fail = should_fail
+            self.closed = False
+            self.sent = []
+
+        def connect(self, _):
+            if self.should_fail:
+                raise ConnectionRefusedError("server not ready")
+
+        def close(self):
+            self.closed = True
+
+        def sendall(self, data):
+            self.sent.append(data)
+
+        def recv(self, _):
+            return _ResponseHeader.PLOT_READY.encode()
+
+    sockets = [FakeSocket(should_fail=True), FakeSocket(should_fail=False)]
+
+    monkeypatch.setattr("bioptim.gui.online_callback_server.socket.socket", lambda *args, **kwargs: sockets.pop(0))
+    monkeypatch.setattr("bioptim.gui.online_callback_server.time.sleep", lambda *_: None)
+    monkeypatch.setattr(
+        "bioptim.gui.online_callback_server.OcpSerializable.from_ocp",
+        lambda ocp: type("FakeSerializable", (), {"serialize": lambda self: {}})(),
+    )
+    monkeypatch.setattr(
+        "bioptim.gui.online_callback_server.OptimizationVectorHelper.extract_step_times", lambda ocp, _: []
+    )
+    monkeypatch.setattr("bioptim.gui.online_callback_server.PlotOcp", lambda *args, **kwargs: "plotter")
+
+    callback = OnlineCallbackServer.__new__(OnlineCallbackServer)
+    callback.ocp = object()
+    callback._host = "localhost"
+    callback._port = 3050
+    callback._socket = None
+    callback._should_wait_ok_to_client_on_new_data = False
+    callback._has_received_ok = lambda: True
+
+    callback._reset_client_socket()
+    first_socket = callback._socket
+
+    callback._initialize_connexion()
+
+    assert first_socket.closed is True
+    assert callback._socket.sent
+    assert callback._plotter == "plotter"
+
+
+def test_online_callback_multiprocess_server_uses_free_port_when_missing(monkeypatch):
+    recorded = {}
+
+    class FakeProcess:
+        def __init__(self, target, kwargs):
+            recorded["process_target"] = target
+            recorded["process_kwargs"] = kwargs
+
+        def start(self):
+            recorded["started"] = True
+
+    def fake_super_init(self, *args, **kwargs):
+        recorded["super_kwargs"] = kwargs
+
+    monkeypatch.setattr("bioptim.gui.online_callback_multiprocess_server._find_available_tcp_port", lambda host: 4242)
+    monkeypatch.setattr("bioptim.gui.online_callback_multiprocess_server.Process", FakeProcess)
+    monkeypatch.setattr(OnlineCallbackServer, "__init__", fake_super_init)
+
+    OnlineCallbackMultiprocessServer(ocp=None)
+
+    assert recorded["process_kwargs"]["port"] == 4242
+    assert recorded["super_kwargs"]["port"] == 4242
+    assert recorded["started"] is True

--- a/tests/shard4/test_solver_options.py
+++ b/tests/shard4/test_solver_options.py
@@ -159,7 +159,9 @@ def test_generic_online_optim_uses_multiprocess_on_linux(monkeypatch):
     callback = object()
 
     monkeypatch.setattr("bioptim.misc.enums.platform.system", lambda: "Linux")
-    monkeypatch.setattr("bioptim.interfaces.interface_utils.OnlineCallbackMultiprocess", lambda *args, **kwargs: callback)
+    monkeypatch.setattr(
+        "bioptim.interfaces.interface_utils.OnlineCallbackMultiprocess", lambda *args, **kwargs: callback
+    )
 
     generic_online_optim(interface, ocp=None)
 
@@ -216,6 +218,9 @@ def test_generic_online_optim_allows_server_on_macos(monkeypatch):
 
 
 def test_online_callback_server_recreates_socket_between_retries(monkeypatch):
+    class FakeOcp:
+        n_phases = 1
+
     class FakeSocket:
         def __init__(self, should_fail=False):
             self.should_fail = should_fail
@@ -249,7 +254,7 @@ def test_online_callback_server_recreates_socket_between_retries(monkeypatch):
     monkeypatch.setattr("bioptim.gui.online_callback_server.PlotOcp", lambda *args, **kwargs: "plotter")
 
     callback = OnlineCallbackServer.__new__(OnlineCallbackServer)
-    callback.ocp = object()
+    callback.ocp = FakeOcp()
     callback._host = "localhost"
     callback._port = 3050
     callback._socket = None

--- a/tests/shard4/test_solver_options.py
+++ b/tests/shard4/test_solver_options.py
@@ -160,7 +160,7 @@ def test_generic_online_optim_uses_multiprocess_on_linux(monkeypatch):
 
     monkeypatch.setattr("bioptim.misc.enums.platform.system", lambda: "Linux")
     monkeypatch.setattr(
-        "bioptim.interfaces.interface_utils.OnlineCallbackMultiprocess", lambda *args, **kwargs: callback
+        "bioptim.interfaces.interface_utils.OnlineCallbackMultiprocessServer", lambda *args, **kwargs: callback
     )
 
     generic_online_optim(interface, ocp=None)


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document [docs/contribution.md]?
* [ ] Have you checked to ensure there aren't other open [Pull Requests] for the same update/change?
* [ ] Have you opened/linked the issue related to your pull request?
* [ ] Have you used the tag [WIP] for on-going changes, and removed it when the pull request was ready?
* [ ] When ready to merge, have you sent a comment pinging @pariterre in it?

### New Feature Submissions:

1. [ ] Does your submission pass the tests (if not please explain why this is intended)?
2. [ ] Did you write a proper documentation (docstrings and ReadMe)
3. [ ] Have you linted your code locally prior to submission (using the command: `black . -l120 --exclude "external/*"`)?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new examples for your core changes, as applicable?
* [ ] Have you written new tests for your core changes, as applicable?

This PR enables `online_optim` on macOS by switching `OnlineOptim.DEFAULT` to `MULTIPROCESS_SERVER` instead of disabling online plotting entirely.

It also fixes the supporting issues that showed up during macOS validation:
- recreate the TCP client socket after failed connect attempts
- auto-pick a free port for the auto-started plotting server
- keep `MULTIPROCESS` explicitly unsupported on macOS
- skip the final `basic_ocp` animation cleanly when `bioviz` is not installed
- ignore all-NaN line data when computing online plot bounds

I split the change into two commits:
1. `c9811420` Enable macOS online plotting via multiprocess server
2. `2b17fb3e` Harden macOS plotting example fallbacks

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/bioptim/1047)
<!-- Reviewable:end -->
