### PR TITLE
get_cmap is a function of matplotlib.pyplot since version 3.8.0

### DIFF
--- a/bioptim/gui/check_conditioning.py
+++ b/bioptim/gui/check_conditioning.py
@@ -2,7 +2,6 @@ import numpy as np
 from casadi import Function, jacobian, hessian, sum1
 from matplotlib import pyplot as plt
 import matplotlib.colors as mcolors
-import matplotlib.cm as mcm
 from ..interfaces.ipopt_interface import IpoptInterface
 
 
@@ -116,7 +115,7 @@ def evaluate_hessian_objective(v, ocp):
 
 def create_conditioning_plots(ocp):
 
-    cmap = mcm.get_cmap("seismic")
+    cmap = plt.get_cmap("seismic")
     cmap.set_bad(color="k")
     interface = IpoptInterface(ocp)
     variables_vector = ocp.variables_vector
@@ -231,7 +230,7 @@ def update_objective_plot(v, ocp):
     hessian_matrix, condition_number, convexity = evaluate_hessian_objective(v, ocp)
     axis_obj = ocp.conditioning_plots["axis_obj"]
     im_objectives_hessian = ocp.conditioning_plots["im_objectives_hessian"]
-    cmap = mcm.get_cmap("seismic")
+    cmap = plt.get_cmap("seismic")
 
     # Hessian objective plot
     hess_min = np.min(hessian_matrix) if hessian_matrix.shape[0] != 0 else 0

--- a/bioptim/gui/ipopt_output_plot.py
+++ b/bioptim/gui/ipopt_output_plot.py
@@ -3,7 +3,6 @@ import pickle
 import numpy as np
 from casadi import jacobian, gradient, sum1, Function
 from matplotlib import pyplot as plt
-from matplotlib.cm import get_cmap
 
 from ..misc.parameters_types import Str, Int
 
@@ -18,7 +17,7 @@ def create_ipopt_output_plot(ocp, interface):
     axs[2].set_ylabel("inf_du", fontweight="bold")
 
     plots = []
-    colors = get_cmap("viridis")
+    colors = plt.get_cmap("viridis")
     for i in range(3):
         plot = axs[i].plot([0], [1], linestyle="-", marker=".", color="k")
         plots.append(plot[0])

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
 - python >=3.10
 - biorbd >=1.12,<1.13
-- matplotlib
+- matplotlib >= 3.8.0
 - pyqt
 - pyqtgraph
 - python-graphviz


### PR DESCRIPTION
Addressing issue #1058 @pariterre

Fixed for this change and `matplotlib>=3.8.0` pinned in `environment.yaml`.

This was a very minor fix and did not affect the environment resolution. No tests failed due to this change. Some are failing for unrelated reasons.

<details>
	<summary>Expand for failed test log</summary>

```
FAILED tests/shard1/test__global_plots.py::test_plot_check_conditioning[PhaseDynamics.ONE_PER_NODE] - ValueError: Figure 'Check conditioning for constraints' already exists. Use plt.figure('Check conditioning for constraints') to get it or plt.close('Check conditioning for constraints') to close it. Alternatively, pass 'clear=True'...
FAILED tests/shard1/test_acados_interface.py::test_acados_no_obj[LINEAR_LS] - ModuleNotFoundError: No module named 'acados_template'
FAILED tests/shard1/test_acados_interface.py::test_acados_no_obj[NONLINEAR_LS] - ModuleNotFoundError: No module named 'acados_template'
FAILED tests/shard1/test_acados_interface.py::test_acados_one_mayer[LINEAR_LS] - ModuleNotFoundError: No module named 'acados_template'
FAILED tests/shard1/test_acados_interface.py::test_acados_one_mayer[NONLINEAR_LS] - ModuleNotFoundError: No module named 'acados_template'
FAILED tests/shard1/test_acados_interface.py::test_acados_mayer_first_node[LINEAR_LS] - ModuleNotFoundError: No module named 'acados_template'
FAILED tests/shard1/test_acados_interface.py::test_acados_mayer_first_node[NONLINEAR_LS] - ModuleNotFoundError: No module named 'acados_template'
FAILED tests/shard1/test_acados_interface.py::test_acados_several_mayer[LINEAR_LS] - ModuleNotFoundError: No module named 'acados_template'
FAILED tests/shard1/test_acados_interface.py::test_acados_several_mayer[NONLINEAR_LS] - ModuleNotFoundError: No module named 'acados_template'
FAILED tests/shard1/test_acados_interface.py::test_acados_one_lagrange[LINEAR_LS] - ModuleNotFoundError: No module named 'acados_template'
FAILED tests/shard1/test_acados_interface.py::test_acados_one_lagrange[NONLINEAR_LS] - ModuleNotFoundError: No module named 'acados_template'
FAILED tests/shard1/test_acados_interface.py::test_acados_one_lagrange_and_one_mayer[LINEAR_LS] - ModuleNotFoundError: No module named 'acados_template'
FAILED tests/shard1/test_acados_interface.py::test_acados_one_lagrange_and_one_mayer[NONLINEAR_LS] - ModuleNotFoundError: No module named 'acados_template'
FAILED tests/shard1/test_acados_interface.py::test_acados_control_lagrange_and_state_mayer[LINEAR_LS] - ModuleNotFoundError: No module named 'acados_template'
FAILED tests/shard1/test_acados_interface.py::test_acados_control_lagrange_and_state_mayer[NONLINEAR_LS] - ModuleNotFoundError: No module named 'acados_template'
FAILED tests/shard1/test_acados_interface.py::test_acados_options[LINEAR_LS] - ModuleNotFoundError: No module named 'acados_template'
FAILED tests/shard1/test_acados_interface.py::test_acados_options[NONLINEAR_LS] - ModuleNotFoundError: No module named 'acados_template'
FAILED tests/shard1/test_acados_interface.py::test_acados_fail_external - ModuleNotFoundError: No module named 'acados_template'
FAILED tests/shard1/test_acados_interface.py::test_acados_fail_lls - ModuleNotFoundError: No module named 'acados_template'
FAILED tests/shard1/test_acados_interface.py::test_acados_custom_dynamics[True] - ModuleNotFoundError: No module named 'acados_template'
FAILED tests/shard1/test_acados_interface.py::test_acados_custom_dynamics[False] - ModuleNotFoundError: No module named 'acados_template'
FAILED tests/shard1/test_acados_interface.py::test_acados_one_parameter - ModuleNotFoundError: No module named 'acados_template'
FAILED tests/shard1/test_acados_interface.py::test_acados_several_parameter - ModuleNotFoundError: No module named 'acados_template'
FAILED tests/shard1/test_acados_interface.py::test_acados_one_end_constraints - ModuleNotFoundError: No module named 'acados_template'
FAILED tests/shard1/test_acados_interface.py::test_acados_constraints_all - ModuleNotFoundError: No module named 'acados_template'
FAILED tests/shard1/test_acados_interface.py::test_acados_constraints_end_all - ModuleNotFoundError: No module named 'acados_template'
FAILED tests/shard1/test_acados_interface.py::test_acados_phase_dynamics_reject - ModuleNotFoundError: No module named 'acados_template'
FAILED tests/shard1/test_acados_interface.py::test_acados_bounds_not_implemented[u_bounds] - ModuleNotFoundError: No module named 'acados_template'
FAILED tests/shard1/test_acados_interface.py::test_acados_bounds_not_implemented[x_bounds] - ModuleNotFoundError: No module named 'acados_template'
FAILED tests/shard1/test_mhe.py::test_mhe[ACADOS-PhaseDynamics.SHARED_DURING_THE_PHASE] - ModuleNotFoundError: No module named 'acados_template'
```
</details>

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document [docs/contribution.md]?
* [x] Have you checked to ensure there aren't other open [Pull Requests] for the same update/change?
* [x] Have you opened/linked the issue related to your pull request?
* [x] Have you used the tag [WIP] for on-going changes, and removed it when the pull request was ready?
* [x] When ready to merge, have you sent a comment pinging @pariterre in it?

### New Feature Submissions:

1. [ ] Does your submission pass the tests (if not please explain why this is intended)?
2. [ ] Did you write a proper documentation (docstrings and ReadMe) N/A
3. [ ] Have you linted your code locally prior to submission (using the command: `black . -l120 --exclude "external/*"`)?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new examples for your core changes, as applicable?
* [ ] Have you written new tests for your core changes, as applicable?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/bioptim/1059)
<!-- Reviewable:end -->
