### PR TITLE
[HOLD] Trigger test workflows on master pushes

### DIFF
--- a/.github/workflows/run_tests_linux.yml
+++ b/.github/workflows/run_tests_linux.yml
@@ -1,6 +1,9 @@
 name: Run the tests
 
-on: [pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/run_tests_osx_win.yml
+++ b/.github/workflows/run_tests_osx_win.yml
@@ -1,6 +1,9 @@
 name: Run the tests
 
-on: [pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
 
 env:
   PREFIX_MACOS: /Users/runner/miniconda3/envs/bioptim


### PR DESCRIPTION
## Summary

- Trigger the Linux test workflow on pushes to `master` in addition to pull requests.
- Trigger the macOS/Windows test workflow on pushes to `master` in addition to pull requests.

## Why

The README CI badge points to the Linux test workflow, but the workflow only ran for pull requests. Since the repository default branch is `master`, completed merges did not refresh the badge status for the default branch.

Fixes #1060.

## Validation

- `git diff --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/bioptim/1061)
<!-- Reviewable:end -->
