### PR TITLE
[WAVE 2][RTR] Fix multiphase rigid contact force plot mapping

### DIFF
--- a/bioptim/dynamics/configure_variables.py
+++ b/bioptim/dynamics/configure_variables.py
@@ -1106,7 +1106,7 @@ class ConfigureVariables:
         else:
             contact_names_in_phase = [name for name in nlp.model.rigid_contact_names]
             axes_idx = BiMapping(
-                to_first=[i for i, c in enumerate(all_contact_names) if c in contact_names_in_phase],
+                to_first=list(range(len(contact_names_in_phase))),
                 to_second=[i for i, c in enumerate(all_contact_names) if c in contact_names_in_phase],
             )
 

--- a/tests/shard5/test_configure_problem.py
+++ b/tests/shard5/test_configure_problem.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import numpy.testing as npt
 import pytest
 from casadi import MX, SX
@@ -178,6 +180,41 @@ def test_configure_soft_contacts(cx):
     npt.assert_equal(nlp.states.keys(), ["soft_contact_forces"])
     npt.assert_equal(nlp.states_dot.shape, 6)
     npt.assert_equal(nlp.states_dot.keys(), ["soft_contact_forces"])
+
+
+def test_rigid_contact_plot_mapping_when_first_contact_is_removed():
+    class Model:
+        def __init__(self, rigid_contact_names):
+            self.rigid_contact_names = rigid_contact_names
+
+        def get_rigid_contact_forces(self, *args, **kwargs):
+            return MX.zeros(len(self.rigid_contact_names), 1)
+
+    def make_nlp(contact_names, phase_idx):
+        empty_variable = SimpleNamespace(scaled=SimpleNamespace(cx=MX.zeros(0, 1)))
+        return SimpleNamespace(
+            model=Model(contact_names),
+            time_cx=MX.sym(f"time_{phase_idx}", 1, 1),
+            dt=MX.sym(f"dt_{phase_idx}", 1, 1),
+            states=empty_variable,
+            controls=empty_variable,
+            parameters=empty_variable,
+            algebraic_states=empty_variable,
+            numerical_timeseries=SimpleNamespace(cx=MX.zeros(0, 1)),
+            plot_mapping={},
+            plot={},
+            phase_idx=phase_idx,
+        )
+
+    phase_0 = make_nlp(["heel", "toe"], 0)
+    phase_1 = make_nlp(["toe"], 1)
+    ocp = SimpleNamespace(nlp=[phase_0, phase_1])
+
+    ConfigureVariables.configure_rigid_contact_function(ocp, phase_1)
+
+    mapping = phase_1.plot["rigid_contact_forces"].phase_mappings
+    npt.assert_equal(mapping.to_first.map_idx, [0])
+    npt.assert_equal(mapping.to_second.map_idx, [1])
 
 
 @pytest.mark.parametrize("cx", [MX, SX])


### PR DESCRIPTION
## Summary

- map phase-local rigid contact force rows to the corresponding global plot axes
- preserve the global contact legend across phases
- add a regression test for removing the first contact in a later phase

## Root cause

The default `BiMapping.to_first` values were derived from global contact indices. The rigid-contact function returns a phase-local vector, so a phase containing only the second global contact attempted to read local row 1 instead of row 0. This produced empty or mislabeled plots.

## Validation

- `MPLCONFIGDIR=/private/tmp/mplconfig-1057 /Users/mickaelbegon/miniconda3/envs/bioptim/bin/python -m pytest tests/shard5/test_configure_problem.py -q`
- 7 passed

Closes #1057

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/bioptim/1062)
<!-- Reviewable:end -->
