### PR TITLE
[HOLD] Test default multinode objective weight

### DIFF
--- a/tests/shard6/test_penalty.py
+++ b/tests/shard6/test_penalty.py
@@ -16,6 +16,8 @@ from bioptim import (
     MultinodeConstraintList,
     MultinodeConstraint,
     MultinodeObjective,
+    MultinodeObjectiveFcn,
+    MultinodeObjectiveList,
     Node,
     ControlType,
     PhaseDynamics,
@@ -205,6 +207,17 @@ def test_penalty_targets_shapes():
     npt.assert_equal(Objective([], custom_type=p, target=[[1], [2]]).target.shape, (2, 1))
     npt.assert_equal(Objective([], custom_type=p, target=[[1, 2]]).target.shape, (1, 2))
     npt.assert_equal(Objective([], custom_type=p, target=np.array([[1, 2]])).target.shape, (1, 2))
+
+
+def test_multinode_objective_default_weight_is_one():
+    objectives = MultinodeObjectiveList()
+    objectives.add(
+        MultinodeObjectiveFcn.STATES_EQUALITY,
+        nodes=(Node.START, Node.END),
+        nodes_phase=(0, 0),
+    )
+
+    npt.assert_equal(objectives[0].weight, ObjectiveWeight(1))
 
 
 @pytest.mark.parametrize("phase_dynamics", [PhaseDynamics.SHARED_DURING_THE_PHASE, PhaseDynamics.ONE_PER_NODE])


### PR DESCRIPTION
## Summary

- add a regression test ensuring multinode objectives default to a weight of 1
- document the behavior requested in #692 in the test suite

## Context

The underlying behavior was already corrected on `master` when objective and constraint weights were separated: `MultinodeObjectiveList.add()` now creates an `ObjectiveWeight()` whose default value is 1. This PR locks that behavior to prevent a future regression to the historical zero-weight behavior.

## Validation

- `MPLCONFIGDIR=/private/tmp/mplconfig-692 /Users/mickaelbegon/miniconda3/envs/bioptim/bin/python -m pytest tests/shard6/test_penalty.py::test_multinode_objective_default_weight_is_one -q`
- 1 passed

Closes #692

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/bioptim/1063)
<!-- Reviewable:end -->
