### PR TITLE
[HOLD] Advance algebraic states in MHE windows

### DIFF
--- a/bioptim/optimization/receding_horizon_optimization.py
+++ b/bioptim/optimization/receding_horizon_optimization.py
@@ -296,6 +296,7 @@ class RecedingHorizonOptimization(OptimalControlProgram):
 
         init_states_have_changed = self.advance_window_initial_guess_states(sol, **advance_options)
         init_controls_have_changed = self.advance_window_initial_guess_controls(sol, **advance_options)
+        init_algebraic_states_have_changed = self.advance_window_initial_guess_algebraic_states(sol, **advance_options)
         init_parameter_have_changed = self.advance_window_initial_guess_parameters(sol, **advance_options)
 
         if self.ocp_solver.opts.type != SolverType.ACADOS:
@@ -303,6 +304,7 @@ class RecedingHorizonOptimization(OptimalControlProgram):
                 self.nlp[0].x_init if init_states_have_changed else None,
                 self.nlp[0].u_init if init_controls_have_changed else None,
                 self.parameter_init if init_parameter_have_changed else None,
+                self.nlp[0].a_init if init_algebraic_states_have_changed else None,
             )
 
     def advance_window_bounds_states(self, sol: Solution, **advance_options) -> Bool:
@@ -365,6 +367,26 @@ class RecedingHorizonOptimization(OptimalControlProgram):
                 (controls[key][:, 1:], controls[key][:, -1][:, np.newaxis]), axis=1
             )
         return True
+
+    def advance_window_initial_guess_algebraic_states(self, sol: Solution, **advance_options) -> Bool:
+        algebraic_states = sol.decision_algebraic_states(to_merge=SolutionMerge.NODES)
+
+        for key in algebraic_states.keys():
+            if self.nlp[0].a_init[key].type != InterpolationType.EACH_FRAME:
+                self.nlp[0].a_init.add(
+                    key,
+                    np.ndarray(algebraic_states[key].shape),
+                    interpolation=InterpolationType.EACH_FRAME,
+                    phase=0,
+                )
+                self.nlp[0].a_init[key].check_and_adjust_dimensions(
+                    len(self.nlp[0].algebraic_states[key]), self.nlp[0].n_algebraic_states_nodes - 1
+                )
+
+            self.nlp[0].a_init[key].init[:, :] = np.concatenate(
+                (algebraic_states[key][:, 1:], algebraic_states[key][:, -1][:, np.newaxis]), axis=1
+            )
+        return bool(algebraic_states)
 
     def advance_window_initial_guess_parameters(self, sol: Solution, **advance_options) -> Bool:
         parameters = sol.parameters
@@ -636,6 +658,24 @@ class CyclicRecedingHorizonOptimization(RecedingHorizonOptimization):
             self.nlp[0].u_init[key].init[:, :] = controls[key][:, :]
         return True
 
+    def advance_window_initial_guess_algebraic_states(self, sol: Solution, **advance_options) -> Bool:
+        algebraic_states = sol.decision_algebraic_states(to_merge=SolutionMerge.NODES)
+
+        for key in algebraic_states.keys():
+            if self.nlp[0].a_init[key].type != InterpolationType.EACH_FRAME:
+                self.nlp[0].a_init.add(
+                    key,
+                    np.ndarray(algebraic_states[key].shape),
+                    interpolation=InterpolationType.EACH_FRAME,
+                    phase=0,
+                )
+                self.nlp[0].a_init[key].check_and_adjust_dimensions(
+                    len(self.nlp[0].algebraic_states[key]), self.nlp[0].n_algebraic_states_nodes - 1
+                )
+
+            self.nlp[0].a_init[key].init[:, :] = algebraic_states[key]
+        return bool(algebraic_states)
+
 
 class MultiCyclicRecedingHorizonOptimization(CyclicRecedingHorizonOptimization):
     def __init__(
@@ -750,6 +790,47 @@ class MultiCyclicRecedingHorizonOptimization(CyclicRecedingHorizonOptimization):
             else:
                 raise NotImplementedError(f"Control type {self.nlp[0].control_type} is not implemented yet")
             self.nlp[0].u_init[key].init[:, :] = controls[key][:, frames]
+
+    def advance_window_initial_guess_algebraic_states(self, sol: Solution, **advance_options) -> Bool:
+        algebraic_states = sol.decision_algebraic_states(to_merge=SolutionMerge.NODES)
+
+        for key in algebraic_states.keys():
+            if isinstance(self.nlp[0].dynamics_type.ode_solver, OdeSolver.COLLOCATION):
+                if self.nlp[0].a_init[key].type != InterpolationType.ALL_POINTS:
+                    self.nlp[0].a_init.add(
+                        key,
+                        np.ndarray((algebraic_states[key].shape[0], self.nlp[0].ns * self.nb_intermediate_frames + 1)),
+                        interpolation=InterpolationType.ALL_POINTS,
+                        phase=0,
+                    )
+                    self.nlp[0].a_init[key].check_and_adjust_dimensions(
+                        self.nlp[0].algebraic_states[key].shape,
+                        self.nlp[0].ns * self.nb_intermediate_frames,
+                    )
+                frames = []
+                for _ in range(self.n_cycles):
+                    frames.extend(
+                        range(
+                            self.n_cycles_to_advance * self.cycle_len * self.nb_intermediate_frames,
+                            (self.n_cycles_to_advance + 1) * self.cycle_len * self.nb_intermediate_frames,
+                        )
+                    )
+                frames.append((self.n_cycles_to_advance + 1) * self.cycle_len * self.nb_intermediate_frames)
+            else:
+                if self.nlp[0].a_init[key].type != InterpolationType.EACH_FRAME:
+                    self.nlp[0].a_init.add(
+                        key,
+                        np.ndarray((algebraic_states[key].shape[0], self.nlp[0].ns + 1)),
+                        interpolation=InterpolationType.EACH_FRAME,
+                        phase=0,
+                    )
+                    self.nlp[0].a_init[key].check_and_adjust_dimensions(
+                        self.nlp[0].algebraic_states[key].shape, self.nlp[0].ns
+                    )
+                frames = self.initial_guess_frames
+
+            self.nlp[0].a_init[key].init[:, :] = algebraic_states[key][:, frames]
+        return bool(algebraic_states)
 
     def solve(
         self,

--- a/tests/shard1/test_mhe.py
+++ b/tests/shard1/test_mhe.py
@@ -2,6 +2,7 @@ import pytest
 import os
 import shutil
 from sys import platform
+from types import SimpleNamespace
 
 from bioptim.misc.enums import SolverType
 from bioptim import (
@@ -18,6 +19,26 @@ import numpy as np
 import numpy.testing as npt
 
 from ..utils import TestUtils
+
+
+def test_mhe_advances_algebraic_state_initial_guesses():
+    mhe = MovingHorizonEstimator.__new__(MovingHorizonEstimator)
+    algebraic_init = SimpleNamespace(
+        type=InterpolationType.EACH_FRAME,
+        init=np.zeros((1, 4)),
+    )
+    mhe.nlp = [SimpleNamespace(a_init={"lambda": algebraic_init})]
+
+    class Solution:
+        @staticmethod
+        def decision_algebraic_states(to_merge):
+            assert to_merge == SolutionMerge.NODES
+            return {"lambda": np.array([[1.0, 2.0, 3.0, 4.0]])}
+
+    changed = mhe.advance_window_initial_guess_algebraic_states(Solution())
+
+    assert changed
+    npt.assert_equal(algebraic_init.init, [[2.0, 3.0, 4.0, 4.0]])
 
 
 @pytest.mark.parametrize("phase_dynamics", [PhaseDynamics.SHARED_DURING_THE_PHASE, PhaseDynamics.ONE_PER_NODE])


### PR DESCRIPTION
## Summary

- advance algebraic-state initial guesses with each receding-horizon window
- pass updated `a_init` values through `update_initial_guess`
- preserve the distinct window-selection behavior of standard, cyclic, and multi-cyclic MHE
- support collocation point selection in the multi-cyclic path
- add a regression test for shifting algebraic states and repeating the terminal value

## Root cause

`RecedingHorizonOptimization.advance_window()` updated state, control, and parameter initial guesses, but never read `Solution.decision_algebraic_states()` and never forwarded `a_init`. Algebraic variables therefore retained stale values between windows.

## Validation

- targeted regression test: 1 passed
- complete `tests/shard1/test_mhe.py`: 7 passed, 1 skipped
- the additional ACADOS case could not be collected locally because `acados_template` is not installed; the failure occurs while importing the ACADOS interface, before the modified path is executed

Closes #971

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/bioptim/1064)
<!-- Reviewable:end -->
