### PR TITLE
[HOLD] Reject all-points control initial guesses

### DIFF
--- a/bioptim/optimization/non_linear_program.py
+++ b/bioptim/optimization/non_linear_program.py
@@ -304,6 +304,9 @@ class NonLinearProgram:
         self, x_init: InitialGuessList | None, u_init: InitialGuessList | None, a_init: InitialGuessList | None
     ) -> None:
 
+        if u_init is not None and u_init.type == InterpolationType.ALL_POINTS:
+            raise ValueError("InterpolationType.ALL_POINTS cannot be used for control initial guesses")
+
         if x_init is not None or a_init is not None:
             not_direct_collocation = not self.dynamics_type.ode_solver.is_direct_collocation
             x_init_all_point = x_init.type == InterpolationType.ALL_POINTS if x_init is not None else False

--- a/tests/shard2/test_global_getting_started.py
+++ b/tests/shard2/test_global_getting_started.py
@@ -426,8 +426,8 @@ def test_initial_guesses(ode_solver, interpolation, random_init, phase_dynamics)
 
     np.random.seed(42)
 
-    if interpolation == InterpolationType.ALL_POINTS and ode_solver.is_direct_shooting:
-        with pytest.raises(ValueError, match="InterpolationType.ALL_POINTS must only be used with direct collocation"):
+    if interpolation == InterpolationType.ALL_POINTS:
+        with pytest.raises(ValueError, match="InterpolationType.ALL_POINTS cannot be used for control initial guesses"):
             _ = ocp_module.prepare_ocp(
                 biorbd_model_path=bioptim_folder + "/examples/models/cube.bioMod",
                 final_time=1,


### PR DESCRIPTION
## Summary

- reject `InterpolationType.ALL_POINTS` for control initial guesses
- report the unsupported interpolation before optimization-vector construction
- update the initial-guess regression test for all randomization and phase-dynamics variants

## Root cause

`NonLinearProgram.update_init` validated `ALL_POINTS` for states and algebraic states but omitted controls. Collocation sub-points exist for state decision variables, not control decision variables, so accepting this interpolation for `u_init` is ambiguous and can lead to inconsistent dimensions.

## Validation

- `MPLCONFIGDIR=/private/tmp/bioptim-mpl-970 python -m pytest tests/shard2/test_global_getting_started.py -k 'test_initial_guesses and ALL_POINTS' -q` (4 passed)
- `git diff --check`

Closes #970

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/bioptim/1066)
<!-- Reviewable:end -->
