### PR TITLE
[WAVE 2][RTR] Validate parameter interpolation types

### DIFF
--- a/bioptim/optimization/optimal_control_program.py
+++ b/bioptim/optimization/optimal_control_program.py
@@ -1093,6 +1093,8 @@ class OptimalControlProgram:
                 )
 
             for key in parameter_bounds.keys():
+                if parameter_bounds[key].type != InterpolationType.CONSTANT:
+                    raise ValueError(f"Parameter bounds for '{key}' must use InterpolationType.CONSTANT")
                 self.parameter_bounds.add(key, parameter_bounds[key], phase=0)
 
         for nlp in self.nlp:
@@ -1156,6 +1158,8 @@ class OptimalControlProgram:
                 )
 
             for key in parameter_init.keys():
+                if parameter_init[key].type != InterpolationType.CONSTANT:
+                    raise ValueError(f"Parameter initial guess for '{key}' must use InterpolationType.CONSTANT")
                 self.parameter_init.add(key, parameter_init[key], phase=0)
 
     def add_plot(self, fig_name: Str, update_function: Callable, phase: Int = -1, **parameters: Any) -> None:

--- a/bioptim/optimization/receding_horizon_optimization.py
+++ b/bioptim/optimization/receding_horizon_optimization.py
@@ -918,7 +918,7 @@ class MultiCyclicRecedingHorizonOptimization(CyclicRecedingHorizonOptimization):
             p_init.add(
                 key,
                 parameters_tp,
-                interpolation=InterpolationType.EACH_FRAME,
+                interpolation=InterpolationType.CONSTANT,
                 phase=0,
             )
 

--- a/tests/shard6/test_update_bounds_and_init.py
+++ b/tests/shard6/test_update_bounds_and_init.py
@@ -212,6 +212,16 @@ def test_update_bounds_and_init_with_param(phase_dynamics):
         parameter_bounds=parameter_bounds,
     )
 
+    invalid_parameter_bounds = BoundsList()
+    invalid_parameter_bounds.add("gravity_z", min_bound=[g_min], max_bound=[g_max])
+    with pytest.raises(ValueError, match="Parameter bounds for 'gravity_z' must use InterpolationType.CONSTANT"):
+        ocp.update_bounds(parameter_bounds=invalid_parameter_bounds)
+
+    invalid_parameter_init = InitialGuessList()
+    invalid_parameter_init.add("gravity_z", [[g_init, g_init]], interpolation=InterpolationType.LINEAR)
+    with pytest.raises(ValueError, match="Parameter initial guess for 'gravity_z' must use InterpolationType.CONSTANT"):
+        ocp.update_initial_guess(parameter_init=invalid_parameter_init)
+
     # Before modifying
     expected = np.array([[0.1] + [-np.inf] * (nq * 2) * (ns + 1) + [-np.inf] * nq * ns + [g_min]]).T
     npt.assert_almost_equal(ocp.bounds_vectors[0], expected)


### PR DESCRIPTION
## Summary

- require `InterpolationType.CONSTANT` for parameter bounds
- apply the same validation to parameter initial guesses
- identify the invalid parameter in the error message
- cover both validation paths in the existing parameter update test

## Root cause

Parameters have no shooting-node dimension, but their bounds and initial guesses were accepted with time-dependent interpolation types. In particular, omitting the interpolation for a `BoundsList` silently selected `CONSTANT_WITH_FIRST_AND_LAST_DIFFERENT`, which is not meaningful for a parameter.

## Validation

- `MPLCONFIGDIR=/private/tmp/bioptim-mpl-863 python -m pytest tests/shard6/test_update_bounds_and_init.py::test_update_bounds_and_init_with_param -q` (2 passed)
- `git diff --check`

Closes #863

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/bioptim/1067)
<!-- Reviewable:end -->
