### PR TITLE
[HOLD] Track variational solver convergence

### DIFF
--- a/tests/shard4/test_variational_integrator_examples.py
+++ b/tests/shard4/test_variational_integrator_examples.py
@@ -30,6 +30,7 @@ def test_variational_pendulum(use_sx):
 
     # --- Solve the ocp --- #
     sol = ocp.solve(Solver.IPOPT())
+    TestUtils.assert_solver_success(sol, max_iterations=100)
     states = sol.decision_states(to_merge=SolutionMerge.NODES)
     controls = sol.decision_controls(to_merge=SolutionMerge.NODES)
 
@@ -64,6 +65,7 @@ def test_variational_pendulum_with_holonomic_constraints(use_sx):
 
     # --- Solve the ocp --- #
     sol = ocp.solve(Solver.IPOPT())
+    TestUtils.assert_solver_success(sol, max_iterations=100)
     states = sol.decision_states(to_merge=SolutionMerge.NODES)
     controls = sol.decision_controls(to_merge=SolutionMerge.NODES)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -31,6 +31,18 @@ from bioptim.interfaces.ipopt_interface import IpoptInterface
 
 class TestUtils:
     @staticmethod
+    def assert_solver_success(solution: Solution, max_iterations: int | None = None):
+        """Assert convergence and optionally guard against a large iteration-count regression."""
+        assert solution.status == 0, (
+            f"Solver did not converge (status={solution.status}, iterations={solution.iterations})"
+        )
+        assert isinstance(solution.iterations, int) and solution.iterations >= 0
+        if max_iterations is not None:
+            assert solution.iterations <= max_iterations, (
+                f"Solver iteration regression: {solution.iterations} iterations, expected at most {max_iterations}"
+            )
+
+    @staticmethod
     def bioptim_folder() -> str:
         return TestUtils._capitalize_folder_drive(str(Path(__file__).parent / "../bioptim"))
 


### PR DESCRIPTION
## Summary

- add a reusable solver-convergence assertion with an optional iteration ceiling
- report solver status and iteration count in assertion failures
- protect four variational-integrator variants against convergence and major iteration regressions

## Rationale

Exact IPOPT iteration counts can vary across platforms and dependency versions. This first increment uses a deliberately broad ceiling of 100 iterations for problems that currently converge comfortably below it, detecting meaningful regressions without making CI unnecessarily brittle.

## Validation

- `MPLCONFIGDIR=/private/tmp/bioptim-mpl-990 python -m pytest tests/shard4/test_variational_integrator_examples.py -vv` (4 passed)
- `git diff --check`

Progress toward #990; this does not close the repository-wide tracking issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/bioptim/1070)
<!-- Reviewable:end -->
