### PR TITLE
[HOLD] Evaluate spline initial guesses at collocation points

### DIFF
--- a/bioptim/limits/path_conditions.py
+++ b/bioptim/limits/path_conditions.py
@@ -317,7 +317,8 @@ class PathCondition(ndarray):
             return self[:, shooting_point]
         elif self.type == InterpolationType.SPLINE:
             spline = interp1d(self.t, self)
-            return spline(shooting_point / self.n_shooting * (self.t[-1] - self.t[0]))
+            time = self.t[0] + shooting_point / (self.n_shooting * repeat) * (self.t[-1] - self.t[0])
+            return spline(time)
         elif self.type == InterpolationType.CUSTOM:
             if self.slice_list is not None:
                 slice_list = self.slice_list

--- a/bioptim/optimization/vector_utils.py
+++ b/bioptim/optimization/vector_utils.py
@@ -109,7 +109,7 @@ def _compute_value_for_node(
     real_keys = [key for key in defined_values.keys() if key != "None"]
     for key in real_keys:
 
-        if defined_values[key].type == InterpolationType.ALL_POINTS:
+        if defined_values[key].type in (InterpolationType.ALL_POINTS, InterpolationType.SPLINE):
             point = node * repeat + sub_node
         else:
             point = _get_interpolation_point(node, sub_node)

--- a/tests/shard5/test_initial_condition.py
+++ b/tests/shard5/test_initial_condition.py
@@ -1,4 +1,5 @@
 import re
+from types import SimpleNamespace
 
 import numpy as np
 import numpy.testing as npt
@@ -19,6 +20,7 @@ from bioptim import (
     SolutionMerge,
 )
 from bioptim.limits.path_conditions import InitialGuess
+from bioptim.optimization.vector_utils import _compute_value_for_node
 from ..utils import TestUtils
 
 # TODO: Add negative test for sizes
@@ -135,6 +137,24 @@ def test_initial_guess_spline():
     for i, t in enumerate(time_to_test):
         expected_val = expected_matrix[:, i]
         npt.assert_almost_equal(init.init.evaluate_at(t), expected_val)
+
+
+def test_initial_guess_spline_at_collocation_points():
+    class VariableContainer(dict):
+        shape = 1
+
+    initial_guesses = InitialGuessList()
+    initial_guesses.add("x", [[0.0, 6.0]], t=[2.0, 8.0], interpolation=InterpolationType.SPLINE)
+    initial_guesses["x"].check_and_adjust_dimensions(1, 2)
+    variables = VariableContainer(x=SimpleNamespace(index=[0]))
+    scaling = {"x": SimpleNamespace(scaling=np.ones((1, 1)))}
+
+    values = [
+        _compute_value_for_node(node, sub_node, 0, 3, variables, initial_guesses, scaling).item()
+        for node in range(2)
+        for sub_node in range(3)
+    ]
+    npt.assert_allclose(values, [0, 1, 2, 3, 4, 5])
 
 
 @pytest.mark.parametrize("phase_dynamics", [PhaseDynamics.SHARED_DURING_THE_PHASE, PhaseDynamics.ONE_PER_NODE])


### PR DESCRIPTION
## Summary
- retain the collocation sub-node index when evaluating spline initial guesses
- account for the number of collocation points in spline time normalization
- include the spline time origin instead of assuming it starts at zero
- add a focused regression test with six distinct values across two intervals

## Root cause
Spline initial guesses were accepted for collocation, but all intermediate points within an interval were collapsed onto one shooting-node time. `PathCondition.evaluate_at` also ignored `repeat` and the spline time offset.

## Validation
- focused spline unit tests
- existing collocation/SPLINE OCP regression
- 3 passed

Progress toward #521.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/bioptim/1077)
<!-- Reviewable:end -->
