### PR TITLE
Expose Ipopt derivative checker options

### DIFF
--- a/bioptim/interfaces/ipopt_options.py
+++ b/bioptim/interfaces/ipopt_options.py
@@ -112,6 +112,12 @@ class IPOPT(GenericSolver):
     _print_level: Int = 5
     _c_compile: Bool = False
     _check_derivatives_for_naninf: Str = "no"  # "yes"
+    _derivative_test: Str = "none"
+    _derivative_test_first_index: Int = -2
+    _derivative_test_perturbation: Float = 1e-8
+    _derivative_test_tol: Float = 1e-4
+    _derivative_test_print_all: Str = "no"
+    _point_perturbation_radius: Float = 10.0
 
     @property
     def tol(self) -> Float:
@@ -210,8 +216,32 @@ class IPOPT(GenericSolver):
         return self._c_compile
 
     @property
-    def check_derivatives_for_naninf(self) -> Bool:
+    def check_derivatives_for_naninf(self) -> Str:
         return self._check_derivatives_for_naninf
+
+    @property
+    def derivative_test(self) -> Str:
+        return self._derivative_test
+
+    @property
+    def derivative_test_first_index(self) -> Int:
+        return self._derivative_test_first_index
+
+    @property
+    def derivative_test_perturbation(self) -> Float:
+        return self._derivative_test_perturbation
+
+    @property
+    def derivative_test_tol(self) -> Float:
+        return self._derivative_test_tol
+
+    @property
+    def derivative_test_print_all(self) -> Str:
+        return self._derivative_test_print_all
+
+    @property
+    def point_perturbation_radius(self) -> Float:
+        return self._point_perturbation_radius
 
     def set_tol(self, val: Float) -> None:
         self._tol = val
@@ -288,6 +318,24 @@ class IPOPT(GenericSolver):
     def set_check_derivatives_for_naninf(self, val: Bool) -> None:
         string_val = "yes" if val else "no"
         self._check_derivatives_for_naninf = string_val
+
+    def set_derivative_test(self, val: Str) -> None:
+        self._derivative_test = val
+
+    def set_derivative_test_first_index(self, index: Int) -> None:
+        self._derivative_test_first_index = index
+
+    def set_derivative_test_perturbation(self, val: Float) -> None:
+        self._derivative_test_perturbation = val
+
+    def set_derivative_test_tol(self, val: Float) -> None:
+        self._derivative_test_tol = val
+
+    def set_derivative_test_print_all(self, val: Bool) -> None:
+        self._derivative_test_print_all = "yes" if val else "no"
+
+    def set_point_perturbation_radius(self, val: Float) -> None:
+        self._point_perturbation_radius = val
 
     def set_convergence_tolerance(self, val: Float) -> None:
         self._tol = val

--- a/tests/shard5/test_solver_options.py
+++ b/tests/shard5/test_solver_options.py
@@ -52,6 +52,12 @@ def test_ipopt_solver_options():
     assert solver.print_level == 5
     assert solver.c_compile is False
     assert solver.check_derivatives_for_naninf == "no"
+    assert solver.derivative_test == "none"
+    assert solver.derivative_test_first_index == -2
+    assert solver.derivative_test_perturbation == 1e-8
+    assert solver.derivative_test_tol == 1e-4
+    assert solver.derivative_test_print_all == "no"
+    assert solver.point_perturbation_radius == 10.0
 
     solver.set_linear_solver("ma57")
     assert solver.linear_solver == "ma57"
@@ -103,6 +109,18 @@ def test_ipopt_solver_options():
     assert solver.c_compile is True
     solver.set_check_derivatives_for_naninf(True)
     assert solver.check_derivatives_for_naninf == "yes"
+    solver.set_derivative_test("first-order")
+    assert solver.derivative_test == "first-order"
+    solver.set_derivative_test_first_index(3)
+    assert solver.derivative_test_first_index == 3
+    solver.set_derivative_test_perturbation(1e-7)
+    assert solver.derivative_test_perturbation == 1e-7
+    solver.set_derivative_test_tol(1e-3)
+    assert solver.derivative_test_tol == 1e-3
+    solver.set_derivative_test_print_all(True)
+    assert solver.derivative_test_print_all == "yes"
+    solver.set_point_perturbation_radius(2.5)
+    assert solver.point_perturbation_radius == 2.5
 
     solver.set_convergence_tolerance(21)
     assert solver.tol == 21


### PR DESCRIPTION
## Summary
- expose IPOPT derivative-test mode and starting index
- expose finite-difference perturbation and mismatch tolerance
- expose full derivative-test printing and point perturbation radius
- keep IPOPT yes/no values behind boolean setters
- correct the existing derivative NaN/Inf getter annotation

This is the second independent slice of #706, limited to derivative diagnostics. Defaults follow the current official IPOPT option reference.

## Validation
- `pytest tests/shard5/test_solver_options.py::test_ipopt_solver_options -q`
- 1 passed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/bioptim/1079)
<!-- Reviewable:end -->
