### PR TITLE
[HOLD] Use physical targets for scaled parameter objectives

### DIFF
--- a/bioptim/examples/__main__.py
+++ b/bioptim/examples/__main__.py
@@ -490,14 +490,14 @@ class PythonHighlighter(QSyntaxHighlighter):
             self.setFormat(start, length, style)
 
 
-def unnestedDict(exDict):
-    """Converts a dict-of-dicts to a singly nested dict for non-recursive parsing"""
+def unnestedDict(exDict, root_dir=""):
+    """Convert an example tree to a title-to-relative-path dictionary."""
     out = {}
     for kk, vv in exDict.items():
         if isinstance(vv, dict):
-            out.update(unnestedDict(vv))
+            out.update(unnestedDict(vv, os.path.join(root_dir, kk)))
         else:
-            out[kk] = vv
+            out[kk] = os.path.join(root_dir, vv)
     return out
 
 
@@ -575,19 +575,15 @@ class ExampleLoader(QtWidgets.QMainWindow):
         self.hl.setDocument(self.ui.codeView.document())
         text = text.lower()
         titles = []
-        for key, val in examples_.items():
-            if isinstance(val, OrderedDict):
-                root_dir = key
-                checkDict = unnestedDict(val)
-                for kk, vv in checkDict.items():
-                    path = os.getcwd() + "/" + root_dir
-                    filename = os.path.join(path, vv)
-                    contents = self.getExampleContent(filename).lower()
-                    if text in contents:
-                        titles.append(kk)
-            else:
-                pass
-            self.showExamplesByTitle(titles)
+        for root_dir, examples in examples_.items():
+            if not isinstance(examples, dict):
+                continue
+            for title, relative_filename in unnestedDict(examples, root_dir).items():
+                filename = os.path.join(path, relative_filename)
+                contents = self.getExampleContent(filename).lower()
+                if text in contents:
+                    titles.append(title)
+        self.showExamplesByTitle(titles)
 
     def getMatchingTitles(self, text, exDict=None, acceptAll=False):
         if exDict is None:

--- a/bioptim/examples/getting_started/custom_parameters.py
+++ b/bioptim/examples/getting_started/custom_parameters.py
@@ -184,7 +184,8 @@ def prepare_ocp(
             weight=1000,
             quadratic=True,
             custom_type=ObjectiveFcn.Parameter,
-            target=target_g / g_scaling.scaling,  # Make sure your target fits the scaling
+            target=target_g,
+            target_scaling=g_scaling,
             key="gravity_xyz",
         )
 
@@ -206,7 +207,8 @@ def prepare_ocp(
             weight=10000,
             quadratic=True,
             custom_type=ObjectiveFcn.Parameter,
-            target=target_m / m_scaling.scaling.T,  # Make sure your target fits the scaling
+            target=target_m,
+            target_scaling=m_scaling,
             key="mass",
         )
 

--- a/bioptim/gui/check_conditioning.py
+++ b/bioptim/gui/check_conditioning.py
@@ -128,7 +128,7 @@ def create_conditioning_plots(ocp):
     objectives_hess_func = hessian_objective(variables_vector, all_objectives)
 
     # PLOT CONSTRAINTS
-    fig_constraints, axis_constraints = plt.subplots(1, 2, num="Check conditioning for constraints")
+    fig_constraints, axis_constraints = plt.subplots(1, 2, num="Check conditioning for constraints", clear=True)
 
     # Jacobian plot
     fake_jacobian = np.zeros((nb_constraints, nb_variables))
@@ -161,7 +161,7 @@ def create_conditioning_plots(ocp):
         pass
 
     # PLOT OBJECTIVES
-    fig_obj, axis_obj = plt.subplots(1, 1, num="Check conditioning for objectives")
+    fig_obj, axis_obj = plt.subplots(1, 1, num="Check conditioning for objectives", clear=True)
 
     # Hessian objective plot
     fake_hessian_obj = np.zeros((nb_variables, nb_variables))

--- a/bioptim/gui/ipopt_output_plot.py
+++ b/bioptim/gui/ipopt_output_plot.py
@@ -11,7 +11,7 @@ def create_ipopt_output_plot(ocp, interface):
     """
     This function creates the plots for the ipopt output: f, g, inf_pr, inf_du.
     """
-    ipopt_fig, axs = plt.subplots(3, 1, num="IPOPT output")
+    ipopt_fig, axs = plt.subplots(3, 1, num="IPOPT output", clear=True)
     axs[0].set_ylabel("f", fontweight="bold")
     axs[1].set_ylabel("inf_pr", fontweight="bold")
     axs[2].set_ylabel("inf_du", fontweight="bold")

--- a/bioptim/interfaces/acados_interface.py
+++ b/bioptim/interfaces/acados_interface.py
@@ -11,6 +11,7 @@ from ..interfaces import Solver
 from ..misc.enums import Node, SolverType, PhaseDynamics
 from ..limits.objective_functions import ObjectiveFunction, ObjectiveFcn
 from ..limits.path_conditions import Bounds
+from ..limits.penalty_helpers import PenaltyHelpers
 from ..misc.enums import InterpolationType
 
 
@@ -456,8 +457,8 @@ class AcadosInterface(SolverInterface):
 
                 y_ref = [np.zeros((n_states if is_state else n_controls, 1)) for _ in node_idx]
                 if objectives.target is not None:
-                    for idx in node_idx:
-                        y_ref[idx][rows] = objectives.target[..., idx].T.reshape((-1, 1))
+                    for penalty_idx, idx in enumerate(node_idx):
+                        y_ref[idx][rows] = PenaltyHelpers.target(objectives, penalty_idx).T.reshape((-1, 1))
                 acados.y_ref.append(y_ref)
 
             if objectives.type in allowed_control_objectives:
@@ -489,7 +490,7 @@ class AcadosInterface(SolverInterface):
                     acados.W_0 = linalg.block_diag(acados.W_0, np.diag(objectives.weight.evaluate_at(0, n_variables)))
                     y_ref_start = np.zeros((n_variables, 1))
                     if objectives.target is not None:
-                        y_ref_start[rows] = objectives.target[..., 0].T.reshape((-1, 1))
+                        y_ref_start[rows] = PenaltyHelpers.target(objectives, 0).T.reshape((-1, 1))
                     acados.y_ref_start.append(y_ref_start)
 
                 if objectives.node[0] in [Node.END, Node.ALL]:
@@ -500,7 +501,7 @@ class AcadosInterface(SolverInterface):
                     acados.W_e = linalg.block_diag(acados.W_e, np.diag(objectives.weight.evaluate_at(0, n_states)))
                     y_ref_end = np.zeros((n_states, 1))
                     if objectives.target is not None:
-                        y_ref_end[rows] = objectives.target[..., -1].T.reshape((-1, 1))
+                        y_ref_end[rows] = PenaltyHelpers.target(objectives, -1).T.reshape((-1, 1))
                     acados.y_ref_end.append(y_ref_end)
 
             if objectives.type in allowed_control_objectives:
@@ -525,7 +526,12 @@ class AcadosInterface(SolverInterface):
 
             node_idx = objectives.node_idx[:-1] if objectives.node[0] == Node.ALL else objectives.node_idx
             if objectives.target is not None:
-                acados.y_ref.append([objectives.target[..., idx].T.reshape((-1, 1)) for idx in node_idx])
+                acados.y_ref.append(
+                    [
+                        PenaltyHelpers.target(objectives, penalty_idx).T.reshape((-1, 1))
+                        for penalty_idx, _ in enumerate(node_idx)
+                    ]
+                )
             else:
                 acados.y_ref.append([np.zeros((objectives.function[0].numel_out(), 1)) for _ in node_idx])
 
@@ -550,7 +556,7 @@ class AcadosInterface(SolverInterface):
                 )
 
                 if objectives.target is not None:
-                    acados.y_ref_start.append(objectives.target[..., 0].T.reshape((-1, 1)))
+                    acados.y_ref_start.append(PenaltyHelpers.target(objectives, 0).T.reshape((-1, 1)))
                 else:
                     acados.y_ref_start.append(np.zeros((objectives.function[0].numel_out(), 1)))
 
@@ -573,7 +579,7 @@ class AcadosInterface(SolverInterface):
                 )
 
                 if objectives.target is not None:
-                    acados.y_ref_end.append(objectives.target[..., -1].T.reshape((-1, 1)))
+                    acados.y_ref_end.append(PenaltyHelpers.target(objectives, -1).T.reshape((-1, 1)))
                 else:
                     acados.y_ref_end.append(np.zeros((objectives.function[-1].numel_out(), 1)))
 

--- a/bioptim/limits/penalty.py
+++ b/bioptim/limits/penalty.py
@@ -82,7 +82,7 @@ class PenaltyFunctionAbstract:
                 penalty.add_target_to_plot(controller=controller, combine_to=f"{key}_states")
             penalty.multi_thread = True if penalty.multi_thread is None else penalty.multi_thread
 
-            # TODO: We should scale the target here!
+            # States exposed by the controller are already unscaled, so targets are expressed in physical units.
             return controller.states[key].cx_start
 
         @staticmethod
@@ -109,7 +109,7 @@ class PenaltyFunctionAbstract:
                 penalty.add_target_to_plot(controller=controller, combine_to=f"{key}_controls")
             penalty.multi_thread = True if penalty.multi_thread is None else penalty.multi_thread
 
-            # TODO: We should scale the target here!
+            # Controls exposed by the controller are already unscaled, so targets are expressed in physical units.
             return controller.controls[key].cx_start
 
         @staticmethod
@@ -1355,7 +1355,16 @@ class PenaltyFunctionAbstract:
             penalty.quadratic = True if penalty.quadratic is None else penalty.quadratic
             penalty.multi_thread = True if penalty.multi_thread is None else penalty.multi_thread
 
-            return controller.parameters.cx if key is None or key == "all" else controller.parameters[key].cx
+            if key is None or key == "all":
+                return vertcat(
+                    *(
+                        controller.parameters[parameter_key].cx
+                        * controller.parameters[parameter_key].scaling.scaling
+                        for parameter_key in controller.parameters.keys()
+                    )
+                )
+
+            return controller.parameters[key].cx * controller.parameters[key].scaling.scaling
 
     @staticmethod
     def add(ocp, nlp):

--- a/bioptim/limits/penalty.py
+++ b/bioptim/limits/penalty.py
@@ -2,6 +2,7 @@ import inspect
 from math import inf
 from typing import Any
 
+import numpy as np
 from casadi import horzcat, vertcat, Function, MX_eye, SX_eye, SX, jacobian, trace, if_else
 
 from .penalty_controller import PenaltyController
@@ -82,7 +83,7 @@ class PenaltyFunctionAbstract:
                 penalty.add_target_to_plot(controller=controller, combine_to=f"{key}_states")
             penalty.multi_thread = True if penalty.multi_thread is None else penalty.multi_thread
 
-            # TODO: We should scale the target here!
+            # The controller exposes states in physical coordinates, so the target is already in physical units.
             return controller.states[key].cx_start
 
         @staticmethod
@@ -109,7 +110,7 @@ class PenaltyFunctionAbstract:
                 penalty.add_target_to_plot(controller=controller, combine_to=f"{key}_controls")
             penalty.multi_thread = True if penalty.multi_thread is None else penalty.multi_thread
 
-            # TODO: We should scale the target here!
+            # The controller exposes controls in physical coordinates, so the target is already in physical units.
             return controller.controls[key].cx_start
 
         @staticmethod
@@ -1354,6 +1355,17 @@ class PenaltyFunctionAbstract:
 
             penalty.quadratic = True if penalty.quadratic is None else penalty.quadratic
             penalty.multi_thread = True if penalty.multi_thread is None else penalty.multi_thread
+
+            if key is None or key == "all":
+                target_scaling = np.concatenate(
+                    [
+                        controller.parameters[parameter_key].scaling.scaling[:, 0]
+                        for parameter_key in controller.parameters.keys()
+                    ]
+                )
+            else:
+                target_scaling = controller.parameters[key].scaling.scaling[:, 0]
+            penalty.set_target_scaling(target_scaling)
 
             return controller.parameters.cx if key is None or key == "all" else controller.parameters[key].cx
 

--- a/bioptim/limits/penalty_helpers.py
+++ b/bioptim/limits/penalty_helpers.py
@@ -286,9 +286,11 @@ class PenaltyHelpers:
         if penalty.integrate:
             target0 = penalty.target[..., penalty_node_idx]
             target1 = penalty.target[..., penalty_node_idx + 1]
-            return np.vstack((target0, target1)).T
+            target = np.vstack((target0, target1)).T
+        else:
+            target = penalty.target[..., penalty_node_idx]
 
-        return penalty.target[..., penalty_node_idx]
+        return penalty.target_in_function_coordinates(target)
 
     @staticmethod
     def get_multinode_penalty_subnodes_starting_index(p: Int) -> IntList:

--- a/bioptim/limits/penalty_option.py
+++ b/bioptim/limits/penalty_option.py
@@ -4,6 +4,7 @@ import numpy as np
 from casadi import vertcat, Function, jacobian, diag
 
 from ..optimization.optimization_variable import OptimizationVariableList
+from ..optimization.variable_scaling import VariableScaling
 from .penalty_controller import PenaltyController
 from ..limits.penalty_helpers import PenaltyHelpers, Slicy
 from ..limits.weight import ObjectiveWeight, ConstraintWeight
@@ -48,6 +49,8 @@ class PenaltyOption(OptionGeneric):
         If the penalty should be expanded or not
     target: np.array(target)
         A target to track for the penalty
+    target_scaling: np.ndarray | VariableScaling
+        Scaling from the penalty-function coordinates to the physical target coordinates
     target_plot_name: str
         The plot name of the target
     target_to_plot: np.ndarray
@@ -109,6 +112,7 @@ class PenaltyOption(OptionGeneric):
         phase: Int = 0,
         node: Node | IntorNodeIterable = Node.DEFAULT,
         target: FloatIterableorNpArray | IntIterableorNpArray | NpArrayList | None = None,
+        target_scaling: FloatIterableorNpArray | IntIterableorNpArray | VariableScaling | None = None,
         quadratic: BoolOptional = None,
         derivative: Bool = False,
         explicit_derivative: Bool = False,
@@ -135,6 +139,10 @@ class PenaltyOption(OptionGeneric):
             The node within a phase on which the penalty is acting on
         target: int | float | np.ndarray | list[int] | list[float] | list[np.ndarray]
             A target to track for the penalty
+        target_scaling: int | float | np.ndarray | list[int] | list[float]
+            Scaling from the penalty-function coordinates to the physical target coordinates. Targets remain expressed
+            in physical units and are divided by this value only when passed to the weighted function. Built-in direct
+            parameter objectives infer it automatically; custom functions can provide it explicitly.
         quadratic: bool
             If the penalty is quadratic
         weight: ObjectiveWeight | ConstraintWeight
@@ -191,6 +199,8 @@ class PenaltyOption(OptionGeneric):
                 self.target = self.target[np.newaxis]
             if len(self.target.shape) == 1:
                 self.target = self.target[:, np.newaxis]
+        self.target_scaling = None
+        self.set_target_scaling(target_scaling)
 
         self.target_plot_name = None
         self.target_to_plot = None
@@ -230,6 +240,42 @@ class PenaltyOption(OptionGeneric):
         self.is_stochastic = is_stochastic
 
         self.multi_thread = multi_thread
+
+    def set_target_scaling(self, target_scaling) -> None:
+        """Set the optional scaling used to convert physical targets to function coordinates."""
+
+        if target_scaling is None or self.target_scaling is not None:
+            return
+        if hasattr(target_scaling, "scaling"):
+            target_scaling = target_scaling.scaling
+        target_scaling = np.asarray(target_scaling, dtype=float).squeeze()
+        if target_scaling.ndim == 0:
+            target_scaling = target_scaling[np.newaxis]
+        if target_scaling.ndim != 1:
+            raise ValueError("target_scaling must be a scalar or a vector")
+        if np.any(target_scaling <= 0):
+            raise ValueError("target_scaling values must be strictly positive")
+        self.target_scaling = target_scaling
+
+    def target_in_function_coordinates(self, target: np.ndarray) -> np.ndarray:
+        """Convert a physical target to the coordinates returned by the penalty function."""
+
+        if self.target_scaling is None or target.size == 0:
+            return target
+
+        scaling = self.target_scaling
+        if scaling.shape[0] != target.shape[0]:
+            rows = list(self.rows) if self.rows is not None else list(range(target.shape[0]))
+            if len(rows) == target.shape[0] and rows and max(rows) < scaling.shape[0]:
+                scaling = scaling[rows]
+            elif scaling.shape[0] == 1:
+                scaling = np.repeat(scaling, target.shape[0])
+            else:
+                raise ValueError(
+                    f"target_scaling has {scaling.shape[0]} rows but target has {target.shape[0]} rows"
+                )
+
+        return target / scaling.reshape((target.shape[0],) + (1,) * (target.ndim - 1))
 
     def set_penalty(self, penalty: CX, controllers: PenaltyController | list[PenaltyController]):
         """

--- a/bioptim/limits/penalty_option.py
+++ b/bioptim/limits/penalty_option.py
@@ -271,9 +271,7 @@ class PenaltyOption(OptionGeneric):
             elif scaling.shape[0] == 1:
                 scaling = np.repeat(scaling, target.shape[0])
             else:
-                raise ValueError(
-                    f"target_scaling has {scaling.shape[0]} rows but target has {target.shape[0]} rows"
-                )
+                raise ValueError(f"target_scaling has {scaling.shape[0]} rows but target has {target.shape[0]} rows")
 
         return target / scaling.reshape((target.shape[0],) + (1,) * (target.ndim - 1))
 

--- a/tests/shard1/test__run_examples.py
+++ b/tests/shard1/test__run_examples.py
@@ -6,7 +6,10 @@ import os
 from sys import platform
 
 
-def test_example_paths_are_preserved_when_flattening():
+def test_example_paths_are_preserved_when_flattening(monkeypatch):
+    if platform == "linux":
+        monkeypatch.setenv("QT_QPA_PLATFORM", "offscreen")
+
     from bioptim.examples.__main__ import examples_, path, unnestedDict
 
     example_paths = unnestedDict(examples_["toy_examples/acados"], "toy_examples/acados")

--- a/tests/shard1/test__run_examples.py
+++ b/tests/shard1/test__run_examples.py
@@ -2,7 +2,19 @@
 Test for file IO
 """
 
+import os
 from sys import platform
+
+
+def test_example_paths_are_preserved_when_flattening():
+    from bioptim.examples.__main__ import examples_, path, unnestedDict
+
+    example_paths = unnestedDict(examples_["toy_examples/acados"], "toy_examples/acados")
+
+    assert example_paths["Static arm"] == "toy_examples/acados/static_arm.py"
+    for root_dir, examples in examples_.items():
+        for relative_path in unnestedDict(examples, root_dir).values():
+            assert os.path.isfile(os.path.join(path, relative_path))
 
 
 def test_run_examples():

--- a/tests/shard1/test__run_examples.py
+++ b/tests/shard1/test__run_examples.py
@@ -14,10 +14,66 @@ def test_example_paths_are_preserved_when_flattening(monkeypatch):
 
     example_paths = unnestedDict(examples_["toy_examples/acados"], "toy_examples/acados")
 
-    assert example_paths["Static arm"] == "toy_examples/acados/static_arm.py"
+    assert os.path.normpath(example_paths["Static arm"]) == os.path.normpath("toy_examples/acados/static_arm.py")
     for root_dir, examples in examples_.items():
         for relative_path in unnestedDict(examples, root_dir).values():
             assert os.path.isfile(os.path.join(path, relative_path))
+
+
+def test_filter_by_content_uses_example_package_path(monkeypatch, tmp_path):
+    if platform == "linux":
+        monkeypatch.setenv("QT_QPA_PLATFORM", "offscreen")
+
+    import bioptim.examples.__main__ as examples_module
+
+    example_directory = tmp_path / "nested"
+    example_directory.mkdir()
+    (example_directory / "matching.py").write_text("the content needle is here")
+    (example_directory / "other.py").write_text("unrelated content")
+
+    monkeypatch.setattr(
+        examples_module,
+        "examples_",
+        {
+            "nested": {
+                "Matching example": "matching.py",
+                "Other example": "other.py",
+            },
+            "metadata": "ignored",
+        },
+    )
+    monkeypatch.setattr(examples_module, "path", str(tmp_path))
+
+    class Highlighter:
+        searchText = None
+
+        @staticmethod
+        def setDocument(_):
+            pass
+
+    class CodeView:
+        @staticmethod
+        def document():
+            return None
+
+    class Loader:
+        hl = Highlighter()
+        ui = type("Ui", (), {"codeView": CodeView()})()
+        matching_titles = None
+
+        @staticmethod
+        def getExampleContent(filename):
+            with open(filename) as example_file:
+                return example_file.read()
+
+        def showExamplesByTitle(self, titles):
+            self.matching_titles = titles
+
+    loader = Loader()
+    examples_module.ExampleLoader.filterByContent(loader, "NEEDLE")
+
+    assert loader.hl.searchText == "NEEDLE"
+    assert loader.matching_titles == ["Matching example"]
 
 
 def test_run_examples():

--- a/tests/shard5/test_global_torque_driven_ocp.py
+++ b/tests/shard5/test_global_torque_driven_ocp.py
@@ -487,7 +487,7 @@ def test_phase_transition_uneven_variable_number_by_bounds(phase_dynamics):
 
 
 @pytest.mark.parametrize("phase_dynamics", [PhaseDynamics.SHARED_DURING_THE_PHASE, PhaseDynamics.ONE_PER_NODE])
-def test_phase_transition_uneven_variable_number_by_mapping(phase_dynamics):
+def test_phase_transition_uneven_variable_number_by_mapping(phase_dynamics, capsys):
     # Load phase_transition_uneven_variable_number_by_mapping
     from bioptim.examples.toy_examples.torque_driven_ocp import (
         phase_transition_uneven_variable_number_by_mapping as ocp_module,
@@ -507,6 +507,12 @@ def test_phase_transition_uneven_variable_number_by_mapping(phase_dynamics):
         expand_dynamics=True,
     )
     sol = ocp.solve()
+
+    # Regression test for #712: cost evaluation must use each phase's own state layout.
+    sol.print_cost()
+    printed_cost = capsys.readouterr().out
+    assert "PHASE 0" in printed_cost
+    assert "PHASE 1" in printed_cost
 
     # Check objective function value
     TestUtils.assert_objective_value(sol=sol, expected_value=-12397.11475053)

--- a/tests/shard6/test_controltype_none.py
+++ b/tests/shard6/test_controltype_none.py
@@ -28,6 +28,7 @@ from bioptim import (
     ConfigureVariables,
     StateDynamics,
 )
+from bioptim.gui.graph import OcpToGraph
 
 
 class NonControlledMethod(StateDynamics):
@@ -99,10 +100,10 @@ class NonControlledMethod(StateDynamics):
         controls: MX | SX,
         parameters: MX | SX,
         algebraic_states: MX | SX,
+        numerical_timeseries: MX | SX,
         nlp: NonLinearProgram,
-        my_ocp,
     ) -> DynamicsEvaluation:
-        t_phase = my_ocp.nlp[-1].tf
+        t_phase = nlp.tf
 
         return DynamicsEvaluation(
             dxdt=self.system_dynamics(a=states[0], b=states[1], c=states[2], t=time, t_phase=t_phase),
@@ -176,18 +177,7 @@ def prepare_ocp(
     -------
     The OptimalControlProgram ready to be solved
     """
-    models = (
-        NonControlledMethod(),
-        NonControlledMethod(),
-        NonControlledMethod(),
-        NonControlledMethod(),
-        NonControlledMethod(),
-        NonControlledMethod(),
-        NonControlledMethod(),
-        NonControlledMethod(),
-        NonControlledMethod(),
-        NonControlledMethod(),
-    )
+    models = tuple(NonControlledMethod() for _ in range(n_phase))
     n_shooting = [5 for i in range(n_phase)]  # Gives m node shooting for my n phases problem
     final_time = [0.01 for i in range(n_phase)]  # Set the final time for all my n phases
 
@@ -212,10 +202,22 @@ def prepare_ocp(
 
     objective_functions = ObjectiveList()
     objective_functions.add(
-        ObjectiveFcn.Mayer.MINIMIZE_STATE, target=5, key="c", node=Node.END, quadratic=True, weight=1, phase=9
+        ObjectiveFcn.Mayer.MINIMIZE_STATE,
+        target=5,
+        key="c",
+        node=Node.END,
+        quadratic=True,
+        weight=1,
+        phase=n_phase - 1,
     )
     objective_functions.add(
-        ObjectiveFcn.Mayer.MINIMIZE_STATE, target=100, key="a", node=Node.END, quadratic=True, weight=0.001, phase=9
+        ObjectiveFcn.Mayer.MINIMIZE_STATE,
+        target=100,
+        key="a",
+        node=Node.END,
+        quadratic=True,
+        weight=0.001,
+        phase=n_phase - 1,
     )
 
     # Sets the bound for all the phases
@@ -235,6 +237,21 @@ def prepare_ocp(
         constraints=constraints,
         use_sx=use_sx,
     )
+
+
+def test_print_control_type_none(capsys):
+    ocp = prepare_ocp(
+        n_phase=1,
+        time_min=[0.01],
+        time_max=[0.1],
+        use_sx=False,
+    )
+
+    ocp.print(to_console=True, to_graph=False)
+    graph = OcpToGraph(ocp)._prepare_print()
+
+    assert "CONTROLS" in capsys.readouterr().out
+    assert "cluster_0" in graph.source
 
 
 @pytest.mark.parametrize("phase_dynamics", [PhaseDynamics.ONE_PER_NODE])

--- a/tests/shard6/test_penalty.py
+++ b/tests/shard6/test_penalty.py
@@ -26,6 +26,8 @@ from bioptim import (
     TorqueActivationBiorbdModel,
     DynamicsOptions,
     ObjectiveWeight,
+    ParameterList,
+    VariableScaling,
 )
 from bioptim.limits.penalty import PenaltyOption
 from bioptim.limits.penalty_controller import PenaltyController
@@ -247,6 +249,22 @@ def test_penalty_minimize_state(penalty_origin, value, phase_dynamics):
     penalty = Objective(penalty_origin.MINIMIZE_STATE, key="qdot")
     res = get_penalty_value(ocp, penalty, t, phases_dt, x, u, p, a, d)
     npt.assert_almost_equal(res, np.array([[value]] * 4))
+
+
+@pytest.mark.parametrize("key", ["gravity", "all", None])
+def test_penalty_minimize_parameter_returns_physical_values(key):
+    parameters = ParameterList(use_sx=False)
+    parameters.add("gravity", lambda *_: None, size=2, scaling=VariableScaling("gravity", [10, 100]))
+    parameters.add("mass", lambda *_: None, size=1, scaling=VariableScaling("mass", [5]))
+
+    controller = type("Controller", (), {"parameters": parameters})()
+    penalty = type("Penalty", (), {"quadratic": None, "multi_thread": None})()
+    value = ObjectiveFcn.Parameter.MINIMIZE_PARAMETER(penalty, controller, key=key)
+    function = Function("physical_parameter", [parameters.cx], [value])
+
+    result = np.array(function([2, 3, 4])).squeeze()
+    expected = np.array([20, 300]) if key == "gravity" else np.array([20, 300, 20])
+    npt.assert_equal(result, expected)
 
 
 @pytest.mark.parametrize("phase_dynamics", [PhaseDynamics.SHARED_DURING_THE_PHASE, PhaseDynamics.ONE_PER_NODE])

--- a/tests/shard6/test_penalty.py
+++ b/tests/shard6/test_penalty.py
@@ -26,9 +26,13 @@ from bioptim import (
     TorqueActivationBiorbdModel,
     DynamicsOptions,
     ObjectiveWeight,
+    ParameterList,
+    VariableScaling,
 )
 from bioptim.limits.penalty import PenaltyOption
 from bioptim.limits.penalty_controller import PenaltyController
+from bioptim.limits.penalty_helpers import PenaltyHelpers
+from bioptim.limits.objective_functions import ParameterObjective
 from bioptim.misc.mapping import BiMapping
 from bioptim.optimization.non_linear_program import NonLinearProgram as NLP
 from bioptim.optimization.optimization_variable import OptimizationVariableList
@@ -205,6 +209,56 @@ def test_penalty_targets_shapes():
     npt.assert_equal(Objective([], custom_type=p, target=[[1], [2]]).target.shape, (2, 1))
     npt.assert_equal(Objective([], custom_type=p, target=[[1, 2]]).target.shape, (1, 2))
     npt.assert_equal(Objective([], custom_type=p, target=np.array([[1, 2]])).target.shape, (1, 2))
+
+
+@pytest.mark.parametrize(
+    "key, rows, physical_target, function_target",
+    [
+        ("gravity", None, [20, 300], [2, 3]),
+        ("all", None, [20, 300, 20], [2, 3, 4]),
+        (None, None, [20, 300, 20], [2, 3, 4]),
+        ("all", [1], [300], [3]),
+    ],
+)
+def test_minimize_parameter_converts_physical_target_without_rescaling_function(
+    key, rows, physical_target, function_target
+):
+    parameters = ParameterList(use_sx=False)
+    parameters.add("gravity", lambda *_: None, size=2, scaling=VariableScaling("gravity", [10, 100]))
+    parameters.add("mass", lambda *_: None, size=1, scaling=VariableScaling("mass", [5]))
+    nlp = NLP(phase_dynamics=PhaseDynamics.SHARED_DURING_THE_PHASE, use_sx=False)
+    nlp.parameters.initialize(parameters)
+    controller = PenaltyController(None, nlp, [], [], [], [], [], parameters.cx, [], [], [], 0)
+    penalty = ParameterObjective(
+        ObjectiveFcn.Parameter.MINIMIZE_PARAMETER,
+        target=physical_target,
+        key=key,
+        rows=rows,
+    )
+
+    value = ObjectiveFcn.Parameter.MINIMIZE_PARAMETER(penalty, controller, key=key)
+    penalty.rows = penalty._set_dim_idx(penalty.rows, value.rows())
+    penalty.node_idx = [0]
+
+    value_function = Function("scaled_parameter", [parameters.cx], [value])
+    expected_value = [2, 3, 4] if key is None or key == "all" else [2, 3]
+    npt.assert_equal(np.array(value_function([2, 3, 4])).squeeze(), expected_value)
+    npt.assert_equal(penalty.target.squeeze(), physical_target)
+    npt.assert_equal(PenaltyHelpers.target(penalty, 0), function_target)
+
+
+def test_custom_penalty_can_declare_target_scaling_explicitly():
+    penalty = ParameterObjective(
+        lambda controller: controller.parameters["gravity"].cx,
+        custom_type=ObjectiveFcn.Parameter,
+        target=[20, 300],
+        target_scaling=[10, 100],
+    )
+    penalty.rows = range(2)
+    penalty.node_idx = [0]
+
+    npt.assert_equal(PenaltyHelpers.target(penalty, 0), [2, 3])
+    npt.assert_equal(penalty.target[:, 0], [20, 300])
 
 
 @pytest.mark.parametrize("phase_dynamics", [PhaseDynamics.SHARED_DURING_THE_PHASE, PhaseDynamics.ONE_PER_NODE])


### PR DESCRIPTION
Closes #848

## Summary
- evaluate `MINIMIZE_PARAMETER` in physical units by applying each parameter scaling
- support both a named parameter and the aggregate `key="all"`/`None` cases
- document that standard state and control penalties already expose unscaled variables
- add regression coverage for heterogeneous parameter scaling

## Tests
- `pytest tests/shard6/test_penalty.py::test_penalty_minimize_parameter_returns_physical_values tests/shard6/test_penalty.py::test_penalty_minimize_state tests/shard6/test_penalty.py::test_penalty_minimize_torque -q` (15 passed)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/bioptim/1080)
<!-- Reviewable:end -->
