### PR TITLE
[PREREQUISITE] Clear reused Matplotlib figures

### DIFF
--- a/bioptim/gui/check_conditioning.py
+++ b/bioptim/gui/check_conditioning.py
@@ -128,7 +128,7 @@ def create_conditioning_plots(ocp):
     objectives_hess_func = hessian_objective(variables_vector, all_objectives)
 
     # PLOT CONSTRAINTS
-    fig_constraints, axis_constraints = plt.subplots(1, 2, num="Check conditioning for constraints")
+    fig_constraints, axis_constraints = plt.subplots(1, 2, num="Check conditioning for constraints", clear=True)
 
     # Jacobian plot
     fake_jacobian = np.zeros((nb_constraints, nb_variables))
@@ -161,7 +161,7 @@ def create_conditioning_plots(ocp):
         pass
 
     # PLOT OBJECTIVES
-    fig_obj, axis_obj = plt.subplots(1, 1, num="Check conditioning for objectives")
+    fig_obj, axis_obj = plt.subplots(1, 1, num="Check conditioning for objectives", clear=True)
 
     # Hessian objective plot
     fake_hessian_obj = np.zeros((nb_variables, nb_variables))

--- a/bioptim/gui/ipopt_output_plot.py
+++ b/bioptim/gui/ipopt_output_plot.py
@@ -11,7 +11,7 @@ def create_ipopt_output_plot(ocp, interface):
     """
     This function creates the plots for the ipopt output: f, g, inf_pr, inf_du.
     """
-    ipopt_fig, axs = plt.subplots(3, 1, num="IPOPT output")
+    ipopt_fig, axs = plt.subplots(3, 1, num="IPOPT output", clear=True)
     axs[0].set_ylabel("f", fontweight="bold")
     axs[1].set_ylabel("inf_pr", fontweight="bold")
     axs[2].set_ylabel("inf_du", fontweight="bold")


### PR DESCRIPTION
## Summary
- clear the named conditioning figures before recreating their axes
- clear the named IPOPT-output figure before recreating its axes

## Root cause

Recent Matplotlib versions reject `plt.subplots(num=...)` when a figure with that name already exists unless `clear=True` is requested. Parametrized tests therefore failed on their second case, independently of the feature PR under test.

## Validation

- `pytest tests/shard1/test__global_plots.py::test_plot_check_conditioning tests/shard1/test__global_plots.py::test_plot_check_conditioning_live tests/shard1/test__global_plots.py::test_plot_ipopt_output_live -q`
- 6 passed

This is a small CI prerequisite for the first review wave (#1068, #1069 and #1076).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/bioptim/1081)
<!-- Reviewable:end -->
