### PR TITLE
docs: add architecture context for contributors and agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Working on bioptim
+
+`bioptim` is a biomechanics optimal-control framework built on CasADi and biorbd.
+Its public API is intentionally broad (`bioptim/__init__.py`); source code and
+tests are the authority when documentation and implementation disagree.
+
+Before any non-trivial change:
+
+1. Read `docs/architecture/LLM_CONTEXT.md` and the relevant source and tests.
+2. Inspect Git with `git status --ignore-submodules=all`; use a clean worktree
+   when the current one contains unrelated work.
+3. Preserve units, signs, reference frames, dimensions, variable/bounds/target
+   scaling, and the selected transcription grid.
+4. Identify the affected backend and variants: MX/SX, RK/collocation,
+   `PhaseDynamics`, control type, and solver adapter when applicable.
+
+Use Conda for development (`environment.yml`, environment name `bioptim`).
+
+Validation is proportional to the change:
+
+- Run the closest test file or node first: `pytest tests/shardN/test_file.py`.
+- For scientific or solver changes, add the relevant solver/grid/phase-dynamics
+  coverage and compare feasibility, cost, status, and dimensions—not only one
+  numerical scalar.
+- Run `black . -l120 --exclude "external/*"` for formatting changes.
+- Treat a CI failure as a baseline issue only after reproducing it on
+  `origin/master` and recording the dependency versions.
+
+Do not add runtime dependencies for documentation or static analysis. Keep
+architecture changes incremental; `external/`, `c_generated_code/`, caches,
+and generated solver artifacts are not source architecture.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# Instructions for Claude and other coding assistants
+
+Read and follow [AGENTS.md](AGENTS.md) before making changes.
+
+For non-trivial work, also read:
+
+- [architecture overview](docs/architecture/OVERVIEW.md)
+- [LLM change context](docs/architecture/LLM_CONTEXT.md)
+
+`AGENTS.md`, source code and tests remain authoritative; this file exists only
+as a discovery entry point for assistants that look for `CLAUDE.md`.

--- a/docs/architecture/LLM_CONTEXT.md
+++ b/docs/architecture/LLM_CONTEXT.md
@@ -1,0 +1,51 @@
+# LLM change context
+
+Read this guide to locate code; then inspect the source and tests themselves.
+
+## Read first
+
+| Task | Read first | Validate first |
+| --- | --- | --- |
+| Add or change an OCP option | `optimization/optimal_control_program.py`, the option class, an analogous example | closest shard test and an example import |
+| Change dynamics or variables | `dynamics/configure_problem.py`, `dynamics/configure_variables.py`, the model class | MX/SX and RK/collocation paths affected |
+| Change objective, constraint, bounds or targets | `limits/penalty*.py`, `limits/path_conditions.py`, controller/tests | scaling, rows/cols/nodes and grid dimensions |
+| Change a solver option or adapter | `interfaces/`, `interfaces/abstract_options.py`, solver tests | affected solver status/options; do not assume adapter equivalence |
+| Change a biomodel feature | `models/protocols/`, matching `models/biorbd/` or `models/pinocchio/` implementation | units, frame, DoF ordering, contacts/external forces |
+| Change a solution, warm start or receding horizon | `optimization/solution/`, `receding_horizon_optimization.py` | solution shape, grid, status and phase/cycle handling |
+| Change a plot or callback | `gui/`, the producing penalty/solution code | a focused smoke test and plot reference where applicable |
+| Diagnose CI numerics | failing test and `origin/master` first | package versions, platform, solver status, feasibility and cost |
+
+## Core flow
+
+`OptimalControlProgram` builds phase-level `NonLinearProgram` objects. Dynamics
+configuration creates symbolic variables and CasADi functions; limits create
+penalties; vector helpers assemble the numerical problem; interfaces solve it;
+`Solution` exposes and reconstructs results. Examples are executable API
+documentation, while shards distribute test duration rather than ownership.
+
+## Safe change procedure
+
+1. Locate an analogous example and direct test.
+2. Identify coordinate systems and dimensions before editing.
+3. Make the smallest coherent source-and-test change.
+4. Run focused tests, then broaden to each affected variant.
+5. For changed numerical results, explain the scientific cause and compare
+   constraints, cost and solver status against a reference.
+6. Run Black for touched Python files and inspect the Git diff.
+
+## Files requiring special care
+
+- `bioptim/__init__.py`: public API facade.
+- `optimization/optimal_control_program.py` and `dynamics/configure_problem.py`:
+  high-fan-in orchestrators.
+- `limits/penalty*.py` and `limits/path_conditions.py`: scaling and grid
+  semantics.
+- `interfaces/`: backend-specific behavior is intentional.
+- `external/` and `c_generated_code/`: do not treat as editable core source.
+
+## Architecture direction
+
+Do not force a general `CLI -> domain -> infrastructure` model. Preserve the
+current OCP-oriented boundaries. The first candidate for an explicit import
+contract is that `bioptim.misc` stays independent of other `bioptim`
+sub-packages; validate it before enforcing it in CI.

--- a/docs/architecture/OVERVIEW.md
+++ b/docs/architecture/OVERVIEW.md
@@ -1,0 +1,67 @@
+# Architecture overview
+
+## Purpose
+
+`bioptim` formulates and solves direct optimal-control problems for biomechanics.
+Users declare models, dynamics, objectives, constraints, bounds, initial guesses
+and solver options; the package constructs symbolic CasADi programs and exposes
+their solutions.
+
+## Observed execution path
+
+```text
+Public API / examples
+    -> OptimalControlProgram and NonLinearProgram
+    -> dynamics configuration + variables + penalties
+    -> transcription and optimization vector
+    -> solver adapter (Ipopt, Acados, SQP, MadNLP)
+    -> Solution reconstruction, integration, plotting and export
+```
+
+This is an OCP-oriented architecture, not a strict layered application. Imports
+between `optimization`, `dynamics`, `limits`, `models`, `interfaces` and `gui`
+are currently interdependent; new layer rules must therefore be introduced only
+when they describe a boundary that already exists.
+
+## Main areas
+
+| Area | Responsibility | Change with special care |
+| --- | --- | --- |
+| `bioptim/optimization` | OCP/NLP assembly, vectors, parameters, solutions, receding horizon | grid dimensions, phase linkage, warm starts, scaling |
+| `bioptim/dynamics` | variable declaration, dynamics configuration and integrators | MX/SX graphs, defects, collocation nodes |
+| `bioptim/limits` | objectives, constraints, bounds, initial guesses, penalties | target/bounds scaling, node selection, weights |
+| `bioptim/interfaces` | solver-specific adapters and options | statuses, multipliers, control/bounds ordering, solver capabilities |
+| `bioptim/models` | biomodel protocols and biorbd/pinocchio implementations | units, frames, DoF ordering, contacts and external forces |
+| `bioptim/misc` | enums, mappings, types and small shared utilities | keep independent of higher-level packages where possible |
+| `bioptim/gui` | plotting and online callbacks | avoid coupling computational core further to display code |
+| `bioptim/examples` | executable API documentation and reference use cases | preserve pedagogical output and update matching tests |
+
+## Critical invariants
+
+- CasADi type (`SX`, `MX`, `DM`), shape and sparsity are semantic.
+- Direct shooting and collocation use different grids (`EACH_FRAME`,
+  `ALL_POINTS`, intermediate nodes); controls may be constant or continuous.
+- Variable, bounds and target scaling must remain in clearly identified
+  coordinates.
+- Biomechanical units, signs, frames, quaternion/root-DoF conventions, contacts
+  and external forces must be verified explicitly.
+- Solver adapters do not share identical notions of convergence, warm start,
+  multipliers or option support.
+
+## Tests and CI
+
+Tests are grouped into `tests/shard1` through `tests/shard6` for execution time,
+not by package. CI creates the Conda environment from `environment.yml`; Acados
+is installed only for Linux shard 1. Numerical regressions must first be compared
+with the same test on `origin/master`, including the resolved package versions.
+
+## Current architecture risks
+
+1. Large orchestrators (`OptimalControlProgram`, `ConfigureProblem`, `Solution`
+   and the penalty system) concentrate many responsibilities.
+2. Dynamic dispatch, callbacks and CasADi function construction make exhaustive
+   static call graphs incomplete; inferred edges must be marked uncertain.
+3. CI dependencies are not fully pinned and the Python requirement differs
+   between `setup.py` and `environment.yml`; numerical baselines can drift.
+4. Plotting, solver adapters and scientific core remain closely coupled in some
+   paths. Refactor only alongside a behavior-preserving, well-tested change.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -34,6 +34,9 @@ It is also a good idea to check the current opened pull-request not to redo some
 If your feature is mentioned in the issue section of GitHub, please assign it to yourself.
 Otherwise, please open a new issue explaining what you are currently working on (and assign it to yourself!).
 
+Before changing core behavior, consult the [architecture overview](architecture/OVERVIEW.md) and the
+[change context](architecture/LLM_CONTEXT.md) to locate the relevant modules, tests and numerical invariants.
+
 As soon as possible, you are asked to open a pull-request (see below) with a short but descriptive name. 
 Unless that pull-request is ready to be merged, please tag it as `work in progress` by adding `[WIP]` at the beginning of the pull-request name.
 If you are ready to get your PR reviewed, you can add the tag `ready to review` by adding `[RTR]`.
@@ -84,4 +87,3 @@ The easiest way to make sure black is happy is to locally run this command:
 black . -l120 --exclude "external/*"
 ```
 If you need to install black, you can do it via conda using the conda-forge channel.
-

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -5,6 +5,7 @@
 * [ ] Have you opened/linked the issue related to your pull request?
 * [ ] Have you used the tag [WIP] for on-going changes, and removed it when the pull request was ready?
 * [ ] When ready to merge, have you sent a comment pinging @pariterre in it?
+* [ ] For core changes, have you checked the architecture context and the directly affected tests?
 
 ### New Feature Submissions:
 


### PR DESCRIPTION
Closes #1098.

## Summary

- add concise repository instructions in `AGENTS.md`;
- add a `CLAUDE.md` discovery entry point requested in the issue;
- document the observed OCP architecture and scientific invariants;
- provide a task-to-source/test context map for contributors and coding agents;
- reference the material from the contribution guide and PR checklist.

## Scope

Documentation only: no runtime dependency, API, numerical behavior, CI rule, or architectural refactor is introduced.

## Validation

- `git diff --check`
- referenced local files and Markdown links checked

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/bioptim/1099)
<!-- Reviewable:end -->
